### PR TITLE
Removing 'umbrella' entries

### DIFF
--- a/cc-database.yaml
+++ b/cc-database.yaml
@@ -3888,7 +3888,7 @@
     - speech acts [cxn]
   AssociatedTo: []
   Definition: >-
-    a <a>speech act</a> which expresses a strong emotional reaction to the <a>propositional content</a> that it conveys. More precisely, the exclamative speech act expresses the speaker's surprise toward the <a>degree</a> of a scalar <a>property</a> contained in the propositional content of the speech act; the rest of the propositional content consists of a <a>presupposed open proposition</a>. <i>Example</i>: <i>What a beautiful house!</i> is an instance of an English exclamative construction. (Sections 12.1, 12.5)
+    a <a>construction</a> that expresses an <a>exclamative</a> speech act. <i>Example</i>: <i>What a beautiful house!</i> is an instance of an English exclamative construction. (Sections 12.1, 12.5)
 
 - Id: exclamative [inf]
   Type: inf
@@ -3899,7 +3899,7 @@
     - speech acts [inf]
   AssociatedTo: []
   Definition: >-
-    a <a>construction</a> that expresses an <a>exclamative</a> speech act. <i>Example</i>: <i>What a beautiful house!</i> is an instance of an English exclamative construction. (Sections 12.1, 12.5)
+    a <a>speech act</a> which expresses a strong emotional reaction to the <a>propositional content</a> that it conveys. More precisely, the exclamative speech act expresses the speaker's surprise toward the <a>degree</a> of a scalar <a>property</a> contained in the propositional content of the speech act; the rest of the propositional content consists of a <a>presupposed open proposition</a>. <i>Example</i>: <i>What a beautiful house!</i> is an instance of an English exclamative construction. (Sections 12.1, 12.5)
 
 - Id: exclusive disjunctive coordination [cxn]
   Type: cxn
@@ -4560,7 +4560,7 @@
     - conditional relation [sem]
   AssociatedTo: []
   Definition: >-
-    a subtype of the conditional relation in which an event causes another event generically or habitually. <i>Example</i>: <i>If/When/Whenever a dog starts barking, I run away</i> is an instance of a generic conditional relation and construction -- it doesn't describe a specific instance of a dog barking causing me to run away; instead, it describes a general or habitual pattern of this causal sequence of events. (Section 17.3.1)
+    a subtype of the <a>conditional relation</a> in which an event causes another event generically or habitually. <i>Example</i>: <i>If/When/Whenever a dog starts barking, I run away</i> is an instance of a generic conditional relation and construction -- it doesn't describe a specific instance of a dog barking causing me to run away; instead, it describes a general or habitual pattern of this causal sequence of events. (Section 17.3.1)
 
 - Id: generic pronoun [cxn]
   Type: cxn
@@ -5377,7 +5377,7 @@
     - speech acts [cxn]
   AssociatedTo: []
   Definition: >-
-    a <a>speech act</a> which requests information, usually of the addressee, regarding uncertain or unknown information that is part of the <a>propositional content</a> of the question. Interrogatives are divided into <a>polarity questions</a>, <a>information questions</a>, and <a>alternative questions</a>. (Sections 12.1, 12.3)
+    the <a>construction</a> that expresses a <a>interrogative</a> speech act. Interrogatives are divided into <a>polarity questions</a>, <a>information questions</a>, and <a>alternative questions</a>. (Sections 12.1, 12.3)
 
 - Id: interrogative [inf]
   Type: inf
@@ -5388,7 +5388,7 @@
     - speech acts [inf]
   AssociatedTo: []
   Definition: >-
-    the <a>construction</a> that expresses a <a>interrogative</a> speech act. Interrogatives are divided into <a>polarity questions</a>, <a>information questions</a>, and <a>alternative questions</a>. (Sections 12.1, 12.3)
+    a <a>speech act</a> which requests information, usually of the addressee, regarding uncertain or unknown information that is part of the <a>propositional content</a> of the question. Interrogatives are divided into <a>polarity questions</a>, <a>information questions</a>, and <a>alternative questions</a>. (Sections 12.1, 12.3)
 
 - Id: interrogative complement [cxn]
   Type: cxn

--- a/cc-database.yaml
+++ b/cc-database.yaml
@@ -10278,7 +10278,7 @@
     - complement-taking predicate [cxn]
   AssociatedTo: []
   Definition: >-
-    the <a>predicate</a> expressing such an <a>utterance event</a>. <i>Example</i>: in <i>Sandy said, <dq>I'm buying the house</dq>, said</i> denotes the utterance event. Some predicates denoting utterance events include the <u>addressee</u> as an <a>argument</a>, as in <i>Sandy told me that she's buying the house</i>. (Section 18.2.2)
+    the <a>predicate</a> expressing an <a>utterance event</a>. <i>Example</i>: in <i>Sandy said, <dq>I'm buying the house</dq>, said</i> denotes the utterance event. Some predicates denoting utterance events include the <u>addressee</u> as an <a>argument</a>, as in <i>Sandy told me that she's buying the house</i>. (Section 18.2.2)
 
 - Id: vague numeral [cxn]
   Type: cxn

--- a/cc-database.yaml
+++ b/cc-database.yaml
@@ -492,36 +492,28 @@
 
 - Id: affecting event [sem]
   Type: sem
-  InstanceOf: affecting event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - affecting event
+    - affecting
   SubtypeOf:
     - experiential event [sem]
   AssociatedTo:
     - stimulus-oriented strategy [str]
-  Definition: ""
-
-- Id: affecting event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - affecting event/verb
-    - affecting
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>experiential event</a> which describes the <a>stimulus</a> causing a change in mental state of the <a>experiencer</a>; and a <a>verb</a> that expresses such an event. <i>Example</i>: <i>The dog surprised me</i> is an instance of an affecting event, and <i>surprise</i> is an affecting verb. (Section 7.4)
+    an <a>experiential event</a> which describes the <a>stimulus</a> causing a change in mental state of the <a>experiencer</a>. <i>Example</i>: <i>The dog surprised me</i> is an instance of an affecting event. (Section 7.4)
 
 - Id: affecting verb [cxn]
   Type: cxn
-  InstanceOf: affecting event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - affecting verb
     - affect
   SubtypeOf:
     - experiential verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>verb</a> that expresses an <a>affecting event</a>. <i>Example</i>: <i>The dog surprised me</i> is an instance of an affecting event, and <i>surprise</i> is an affecting verb. (Section 7.4)
 
 - Id: affixation [str]
   Type: str
@@ -558,35 +550,26 @@
 
 - Id: agentive change of state event [sem]
   Type: sem
-  InstanceOf: agentive change of state event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - agentive change of state event
   SubtypeOf:
     - change of state event [sem]
   AssociatedTo:
     - bivalent event [sem]
-  Definition: ""
-
-- Id: agentive change of state event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - agentive change of state event/verb
-    - agentive change of state
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>change of state event</a> in which an external volitional <a>agent</a> brings about a change in a <a>patient</a> such that the patient enters a resulting <a>state</a>; and the <a>verb</a> that expresses such an event. <i>Example</i>: the event of a person drying dishes is an agentive change of state event, and <i>dry</i> is an agentive change of state verb. (Section 6.2.1)
+    a <a>change of state event</a> in which an external volitional <a>agent</a> brings about a change in a <a>patient</a> such that the patient enters a resulting <a>state</a>. <i>Example</i>: the event of a person drying dishes is an agentive change of state event. (Section 6.2.1)
 
 - Id: agentive change of state verb [cxn]
   Type: cxn
-  InstanceOf: agentive change of state event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - agentive change of state verb
   SubtypeOf:
     - change of state verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>verb</a> that expresses an agentive change of state event. <i>Example</i>: the event of a person drying dishes is an agentive change of state event, and <i>dry</i> is an agentive change of state verb. (Section 6.2.1)
 
 - Id: agree/disagree alignment strategy [str]
   Type: str
@@ -675,33 +658,26 @@
 
 - Id: alternative question [cxn]
   Type: cxn
-  InstanceOf: alternative question [inf/cxn]
+  InstanceOf: ""
   Alias:
     - alternative question
   SubtypeOf:
     - interrogative [cxn]
   AssociatedTo: []
-  Definition: ""
-
-- Id: alternative question [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - alternative question
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an interrogative in which the speaker offers a closed list of alternatives to fill in the unknown piece of information in the propositional content; and the construction expressing this function. <i>Example</i>: <i>Do you prefer beer or wine?</i> is an instance of an alternative question construction, where the alternatives offered are beer and wine. (Section 12.3.1)
+    a construction expressing the <a>alternative question function</a>. <i>Example</i>: <i>Do you prefer beer or wine?</i> is an instance of an alternative question construction, where the alternatives offered are beer and wine. (Section 12.3.1)
 
 - Id: alternative question [inf]
   Type: inf
-  InstanceOf: alternative question [inf/cxn]
+  InstanceOf: ""
   Alias:
     - alternative question
+    - alternative question function
   SubtypeOf:
     - interrogative [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    an interrogative in which the speaker offers a closed list of alternatives to fill in the unknown piece of information in the propositional content. <i>Example</i>: <i>Do you prefer beer or wine?</i> is an instance of an alternative question construction, where the alternatives offered are beer and wine. (Section 12.3.1)
 
 - Id: amount term [cxn]
   Type: cxn
@@ -914,68 +890,55 @@
 
 - Id: apodosis [cxn]
   Type: cxn
-  InstanceOf: apodosis [sem/cxn]
+  InstanceOf: ""
   Alias:
     - apodosis
+    - apodosis clause
   SubtypeOf:
     - clause [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>clause</a> expressing the causally consequent <a>proposition</a> in a <a>causal</a>, <a>conditional</a>, <a>concessive</a>, <a>concessive conditional</a>, or <a>comparative conditional construction</a>. <i>Example</i>: in <i>If you press this button, the door will open</i>, <i>the door will open</i> is the apodosis; <i>If you press this button</i> is the <a>protasis</a>. (Section 17.3.1)
 
-- Id: apodosis [sem/cxn]
-  Type: sem/cxn
+- Id: apodosis [sem]
+  Type: sem
   InstanceOf: ""
   Alias:
     - apodosis
     - consequent
-  SubtypeOf: []
-  AssociatedTo: []
-  Definition: >-
-    the <a>clause</a> expressing the causally consequent <a>proposition</a> in a <a>causal</a>, <a>conditional</a>, <a>concessive</a>, <a>concessive conditional</a>, or <a>comparative conditional construction</a>; or the proposition or event denoted by the clause. <i>Example</i>: in <i>If you press this button, the door will open</i>, <i>the door will open</i> is the apodosis; <i>If you press this button</i> is the <a>protasis</a>. Since the conditional relations are defined in terms of both logical implication and causal relation, the semantic use of <q>apodosis</q> can be distinguished as <q>apodosis proposition</q> or <q>apodosis event</q>. (Section 17.3.1)
-
-- Id: apodosis [sem]
-  Type: sem
-  InstanceOf: apodosis [sem/cxn]
-  Alias:
-    - apodosis
   SubtypeOf:
+    - event [sem]
     - proposition [sem]
   AssociatedTo:
     - conditional relation [sem]
-  Definition: ""
+  Definition: >-
+    the proposition or event denoted by an <a>apodosis clause</a>. <i>Example</i>: in <i>If you press this button, the door will open</i>, <i>the door will open</i> is the apodosis; <i>If you press this button</i> is the <a>protasis</a>. Since the conditional relations are defined in terms of both logical implication and causal relation, the semantic use of <q>apodosis</q> can be distinguished as <q>apodosis proposition</q> or <q>apodosis event</q>. (Section 17.3.1)
 
 - Id: application event [sem]
   Type: sem
-  InstanceOf: application event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - application event
+    - application
+    - putting event
   SubtypeOf:
     - trivalent event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: application event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - application event/verb
-    - application
-    - putting event/verb
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> describing placing or applying one <a>object</a> onto (2-dimensional) or into (3-dimensional) another object; and the <a>verb</a> expressing such an event. <i>Examples</i>: smearing (2-dimensional) and loading (3-dimensional) are application events. (Section 7.3.2)
+    an <a>event</a> describing placing or applying one <a>object</a> onto (2-dimensional) or into (3-dimensional) another object. <i>Examples</i>: smearing (2-dimensional) and loading (3-dimensional) are application events. (Section 7.3.2)
 
 - Id: application verb [cxn]
   Type: cxn
-  InstanceOf: application event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - application verb
+    - putting verb
   SubtypeOf:
     - result verb [cxn]
     - manner verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing an <a>application event</a>. <i>Examples</i>: smearing (2-dimensional) and loading (3-dimensional) are application events. (Section 7.3.2)
 
 - Id: applicative construction [cxn]
   Type: cxn
@@ -1166,36 +1129,28 @@
 
 - Id: attending event [sem]
   Type: sem
-  InstanceOf: attending event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - attending event
+    - attending
   SubtypeOf:
     - experiential event [sem]
   AssociatedTo:
     - experiential verb [cxn]
     - experiencer-oriented strategy [str]
-  Definition: ""
-
-- Id: attending event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - attending event/verb
-    - attending
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>experiential event</a> which describes the <a>experiencer</a> directing her/his attention to the <a>stimulus</a>; and a <a>verb</a> that expresses such an event. <i>Example</i>: <i>I am looking at the sandhill crane</i> is an instance of an attending event, and <i>look (at)</i> is an attending verb. (Section 7.4)
+    an <a>experiential event</a> which describes the <a>experiencer</a> directing her/his attention to the <a>stimulus</a>. <i>Example</i>: <i>I am looking at the sandhill crane</i> is an instance of an attending event. (Section 7.4)
 
 - Id: attending verb [cxn]
   Type: cxn
-  InstanceOf: attending event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - attending verb
   SubtypeOf:
     - experiential verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+     a <a>verb</a> that expresses an <a>attending event</a>. <i>Example</i>: <i>I am looking at the sandhill crane</i> is an instance of an attending event, and <i>look (at)</i> is an attending verb. (Section 7.4)
 
 - Id: attributive phrase [cxn]
   Type: cxn
@@ -1392,100 +1347,74 @@
 
 - Id: bodily action [sem]
   Type: sem
-  InstanceOf: bodily action [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
+    - bodily
     - bodily action
   SubtypeOf:
     - experiential event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: bodily action [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - bodily action/predicate
-    - bodily
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    the <a>event</a> class of normally uncontrolled actions involving one's body; and the <a>predicates</a> that express events in this class. <i>Example</i>: coughing is a bodily action, and <i>cough</i> is a bodily action predicate. (Section 6.3.3)
+    the <a>event</a> class of normally uncontrolled actions involving one's body. <i>Example</i>: coughing is a bodily action. (Section 6.3.3)
 
 - Id: bodily motion event [sem]
   Type: sem
-  InstanceOf: bodily motion event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - bodily motion event
   SubtypeOf:
     - monovalent event [sem]
   AssociatedTo:
     - middle voice [str]
-  Definition: ""
-
-- Id: bodily motion event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - bodily motion event/verb
-    - bodily motion
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>monovalent event</a> involving an internal bodily motion; and the <a>verb</a> expressing that event. <i>Example</i>: <i>stretch out (oneself)</i> expresses a bodily motion event. (Section 7.2)
+    a <a>monovalent event</a> involving an internal bodily motion. <i>Example</i>: <i>stretch out (oneself)</i> expresses a bodily motion event. (Section 7.2)
 
 - Id: bodily motion verb [cxn]
   Type: cxn
-  InstanceOf: bodily motion event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - bodily motion verb
   SubtypeOf:
     - introverted verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing a <a>bodily motion event</a>. <i>Example</i>: <i>stretch out (oneself)</i> expresses a bodily motion event. (Section 7.2)
 
 - Id: bodily predicate [cxn]
   Type: cxn
-  InstanceOf: bodily action [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - bodily predicate
   SubtypeOf:
     - experiential verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>predicates</a> that express events in the <a>bodily action<a> event class. <i>Example</i>: coughing is a bodily action, and <i>cough</i> is a bodily action predicate. (Section 6.3.3)
 
 - Id: body care event [sem]
   Type: sem
-  InstanceOf: body care event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - body care event
+    - body care
     - grooming event
   SubtypeOf:
     - monovalent event [sem]
   AssociatedTo:
     - middle voice [str]
-  Definition: ""
-
-- Id: body care event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - body care event/verb
-    - body care
-    - grooming event/verb
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>monovalent event</a> involving a person acting on that person's own body, generally for grooming or hygiene; and the <a>verb</a> expressing that event. <i>Examples</i>: <i>shave</i> and <i>wash (oneself)</i> express body care events. (Section 7.2)
+    a <a>monovalent event</a> involving a person acting on that person's own body, generally for grooming or hygiene. <i>Examples</i>: <i>shave</i> and <i>wash (oneself)</i> express body care events. (Section 7.2)
 
 - Id: body care verb [cxn]
   Type: cxn
-  InstanceOf: body care event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - body care verb
   SubtypeOf:
     - introverted verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing a <a>body care event</a>. <i>Examples</i>: <i>shave</i> and <i>wash (oneself)</i> express body care events. (Section 7.2)
 
 - Id: body part relation [sem]
   Type: sem
@@ -1501,40 +1430,39 @@
 
 - Id: body position event [sem]
   Type: sem
-  InstanceOf: body position event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - body position event
+    - body position
+    - posture event
+    - posture
+    - maintain position event
+    - maintain position
+    - locative stative event
+    - locative stative
   SubtypeOf:
     - event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: body position event [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - body position event/predicate
-    - body position
-    - posture event/predicate
-    - maintain position event/predicate
-    - locative stative event/predicate
-    - locative stative
-    - maintain position
-    - posture
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    the event class of maintaining a particular body posture or position; and the <a>predicates</a> that express events in this class. <i>Example</i>: standing is a body position event, and <i>stand</i> is a body position predicate. (Section 6.3.3)
+    the event class of maintaining a particular body posture or position. <i>Example</i>: standing is a body position event. (Section 6.3.3)
 
 - Id: body position predicate [cxn]
   Type: cxn
-  InstanceOf: body position event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - body position predicate
+    - body position
+    - posture predicate
+    - posture
+    - maintain position predicate
+    - maintain position
+    - locative stative predicate
+    - locative stative
   SubtypeOf:
     - predicate [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>predicates</a> that express events in the <a>body position event</a> class. <i>Example</i>: standing is a body position event, and <i>stand</i> is a body position predicate. (Section 6.3.3)
 
 - Id: cardinal numeral [cxn]
   Type: cxn
@@ -1717,38 +1645,30 @@
 
 - Id: chaining construction [cxn]
   Type: cxn
-  InstanceOf: chaining event [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - chaining construction
   SubtypeOf:
     - reference tracking [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>construction</a> expressing such a <a>chaining event</a>. <i>Example</i>: in <i>The guests followed one another into the room</i>, each guest is a follower and a <dq>followee</dq>, except the first and last in the chain. It is also possible to have a closed chain, as in people following each other in a circle, in which all participants are both initiator and endpoint. (Section 7.2)
 
 - Id: chaining event [sem]
   Type: sem
-  InstanceOf: chaining event [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - chaining event
+    - chaining
   SubtypeOf:
     - event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: chaining event [sem] / construction [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - chaining event/construction
-    - chaining
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> type in which one <a>participant</a> acts upon another participant, and the second participant acts on a third participant in the same way, and so on; and the <a>construction</a> expressing such an event. That is, each participant in the chain is both the <a>initiator</a> and <a>endpoint</a> of <a>transmission of force</a> for the same type of action -- except the first in the chain, who is only an initiator, and the last, who is only an endpoint. <i>Example</i>: in <i>The guests followed one another into the room</i>, each guest is a follower and a <dq>followee</dq>, except the first and last in the chain. It is also possible to have a closed chain, as in people following each other in a circle, in which all participants are both initiator and endpoint. (Section 7.2)
+    an <a>event</a> type in which one <a>participant</a> acts upon another participant, and the second participant acts on a third participant in the same way, and so on. That is, each participant in the chain is both the <a>initiator</a> and <a>endpoint</a> of <a>transmission of force</a> for the same type of action -- except the first in the chain, who is only an initiator, and the last, who is only an endpoint. <i>Example</i>: in <i>The guests followed one another into the room</i>, each guest is a follower and a <dq>followee</dq>, except the first and last in the chain. It is also possible to have a closed chain, as in people following each other in a circle, in which all participants are both initiator and endpoint. (Section 7.2)
 
 - Id: change in (body) position event [sem]
   Type: sem
-  InstanceOf: change in (body) position event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - change in (body) position event
     - change in body position event
@@ -1759,26 +1679,12 @@
     - monovalent event [sem]
   AssociatedTo:
     - middle voice [str]
-  Definition: ""
-
-- Id: change in (body) position event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - change in (body) position event/verb
-    - change in (body) position
-    - change in body position
-    - change in position
-    - assume position
-    - change in posture
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>monovalent event</a> involving a person changing their bodily position; and the <a>verb</a> expressing that event. <i>Example</i>: <i>sit</i> and <i>lean</i> express change in body posture events. (Section 7.2)
+    a <a>monovalent event</a> involving a person changing their bodily position. <i>Example</i>: <i>sit</i> and <i>lean</i> express change in body posture events. (Section 7.2)
 
 - Id: change in (body) position verb [cxn]
   Type: cxn
-  InstanceOf: change in (body) position event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - change in (body) position verb
     - change in body position verb
@@ -1788,41 +1694,35 @@
   SubtypeOf:
     - introverted verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing a <a>change in body position event</a>. <i>Example</i>: <i>sit</i> and <i>lean</i> express change in body posture events. (Section 7.2)
 
 - Id: change of state event [sem]
   Type: sem
-  InstanceOf: change of state event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - change of state event
+    - change of state
+    - COS event
+    - COS
   SubtypeOf:
     - event [sem]
   AssociatedTo:
     - monovalent event [sem]
-  Definition: ""
-
-- Id: change of state event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - change of state event/verb
-    - change of state
-    - COS event/verb
-    - COS
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> in which a <a>participant</a>, the <a>patient</a>, undergoes a change such that the patient enters a resulting <a>state</a>, usually a change of physical state; and the <a>verb</a> expressing that event. <i>Example</i>: the event of dishes becoming dry is a change of state event, and <i>dry</i> is a change of state verb. (Sections 6.1.2, <b>6.2.1</b>)
+    an <a>event</a> in which a <a>participant</a>, the <a>patient</a>, undergoes a change such that the patient enters a resulting <a>state</a>, usually a change of physical state. <i>Example</i>: the event of dishes becoming dry is a change of state event. (Sections 6.1.2, <b>6.2.1</b>)
 
 - Id: change of state verb [cxn]
   Type: cxn
   InstanceOf: change of state event [sem] / verb [cxn]
   Alias:
     - change of state verb
+    - COS verb
   SubtypeOf:
     - verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing a <a>change of state event</a>. <i>Example</i>: the event of dishes becoming dry is a change of state event, and <i>dry</i> is a change of state verb. (Sections 6.1.2, <b>6.2.1</b>)
 
 - Id: choosing [inf]
   Type: inf
@@ -1910,67 +1810,51 @@
 
 - Id: cognition event [sem]
   Type: sem
-  InstanceOf: cognition event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - cognition event
+    - cognition
   SubtypeOf:
     - experiential event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: cognition event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - cognition event/verb
-    - cognition
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>experiential event</a> involving an <a>experiencer</a>'s cognition directed toward a <a>stimulus</a>; and a <a>verb</a> that expresses such an event. <i>Example</i>: <i>Tim thought about the war</i> is an example of a cognition event, and <i>think (about)</i> is the cognition verb. (Section 7.4)
+    an <a>experiential event</a> involving an <a>experiencer</a>'s cognition directed toward a <a>stimulus</a>. <i>Example</i>: <i>Tim thought about the war</i> is an example of a cognition event. (Section 7.4)
 
 - Id: cognition verb [cxn]
   Type: cxn
-  InstanceOf: cognition event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - cognition verb
   SubtypeOf:
     - experiential verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>verb</a> that expresses a <a>cognition event</a>. <i>Example</i>: <i>Tim thought about the war</i> is an example of a cognition event, and <i>think (about)</i> is the cognition verb. (Section 7.4)
 
 - Id: collective construction [cxn]
   Type: cxn
-  InstanceOf: collective event [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - collective construction
   SubtypeOf:
     - reference tracking [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>construction</a> expressing a <a>collective event</a>. <i>Example</i>: in <i>Mary and Sue left together</i>, Mary leaves and Sue leaves, and the two leaving events are connected. (Section 7.2)
 
 - Id: collective event [sem]
   Type: sem
-  InstanceOf: collective event [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - collective event
+    - collective
   SubtypeOf:
     - event [sem]
   AssociatedTo:
     - reciprocal construction [cxn]
     - reflexive construction [cxn]
-  Definition: ""
-
-- Id: collective event [sem] / construction [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - collective event/construction
-    - collective
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> type in which two <a>participants</a> both play the same role in two related events (that is, they do it <dq>together</dq>); and the <a>construction</a> expressing such an event. <i>Example</i>: in <i>Mary and Sue left together</i>, Mary leaves and Sue leaves, and the two leaving events are connected. (Section 7.2)
+    an <a>event</a> type in which two <a>participants</a> both play the same role in two related events (that is, they do it <dq>together</dq>). <i>Example</i>: in <i>Mary and Sue left together</i>, Mary leaves and Sue leaves, and the two leaving events are connected. (Section 7.2)
 
 - Id: color term [cxn]
   Type: cxn
@@ -1985,35 +1869,27 @@
 
 - Id: combining event [sem]
   Type: sem
-  InstanceOf: combining event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - combining event
+    - combining
   SubtypeOf:
     - event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: combining event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - combining event/verb
-    - combining
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> describing the combining of two <a>objects</a>; and the <a>verb</a> expressing such an event. <i>Example</i>: blending is a combining event. (Section 7.3.2)
+    an <a>event</a> describing the combining of two <a>objects</a>. <i>Example</i>: blending is a combining event. (Section 7.3.2)
 
 - Id: combining verb [cxn]
   Type: cxn
-  InstanceOf: combining event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - combining verb
   SubtypeOf:
     - result verb [cxn]
     - manner verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing a <a>combining event</a>. <i>Example</i>: blending is a combining event. (Section 7.3.2)
 
 - Id: comitative [sem]
   Type: sem
@@ -2040,25 +1916,16 @@
 
 - Id: commentative event [sem]
   Type: sem
-  InstanceOf: commentative event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - commentative event
+    - commentative
   SubtypeOf:
     - evaluative event [sem]
   AssociatedTo:
     - factive event [sem]
-  Definition: ""
-
-- Id: commentative event [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - commentative event/predicate
-    - commentative
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>evaluative event</a> in which an evaluative judgment about a <a>proposition</a> expressed by the <a>complement</a> of the commentative event is made, and there is a <a>positive epistemic stance</a> by the speaker toward the proposition; and the <a>predicate</a> expressing that event. <i>Example</i>: in <i>Nancy is glad that Joe won the election</i>, the commentative predicate <i>is glad</i> expresses Nancy's evaluation of Joe's winning the election, and also presupposes that the speaker believes that Joe indeed won the election. (Section 18.2.2)
+    an <a>evaluative event</a> in which an evaluative judgment about a <a>proposition</a> expressed by the <a>complement</a> of the commentative event is made, and there is a <a>positive epistemic stance</a> by the speaker toward the proposition. <i>Example</i>: in <i>Nancy is glad that Joe won the election</i>, the commentative predicate <i>is glad</i> expresses Nancy's evaluation of Joe's winning the election, and also presupposes that the speaker believes that Joe indeed won the election. (Section 18.2.2)
 
 - Id: commentative predicate [cxn]
   Type: cxn
@@ -2068,7 +1935,8 @@
   SubtypeOf:
     - evaluative predicate [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>predicate</a> expressing a <a>commentative event</a>. <i>Example</i>: in <i>Nancy is glad that Joe won the election</i>, the commentative predicate <i>is glad</i> expresses Nancy's evaluation of Joe's winning the election, and also presupposes that the speaker believes that Joe indeed won the election. (Section 18.2.2)
 
 - Id: common noun [cxn]
   Type: cxn
@@ -2095,31 +1963,23 @@
 
 - Id: comparative conditional construction [cxn]
   Type: cxn
-  InstanceOf: comparative conditional relation [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - comparative conditional construction
   SubtypeOf:
     - adverbial clause construction [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a construction that expresses a <a>comparative conditional relation</a>. <i>Example</i>: <i>The longer that Bill had to wait, the angrier he got</i> is an instance of the comparative conditional relation and construction: a degree of length of time that Bill had to wait can (in a <a>generic conditional</a>) or does (in an ordinary, specific <a>conditional</a>) cause the occurrence of the corresponding degree of Bill's anger. (Section 17.4.1)
 
 - Id: comparative conditional relation [sem]
   Type: sem
-  InstanceOf: comparative conditional relation [sem] / construction [cxn]
-  Alias:
-    - comparative conditional relation
-  SubtypeOf:
-    - semantic relation (FN-Br) [sem]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: comparative conditional relation [sem] / construction [cxn]
-  Type: sem/cxn
   InstanceOf: ""
   Alias:
-    - comparative conditional relation/construction
+    - comparative conditional relation
     - comparative conditional
-  SubtypeOf: []
+  SubtypeOf:
+    - semantic relation (FN-Br) [sem]
   AssociatedTo: []
   Definition: >-
     a relation between two events, each on a <a>gradable predicative scale</a>, such that an event at one degree on the first predicative scale causes an event at the corresponding degree on the second predicative scale. <i>Example</i>: <i>The longer that Bill had to wait, the angrier he got</i> is an instance of the comparative conditional relation and construction: a degree of length of time that Bill had to wait can (in a <a>generic conditional</a>) or does (in an ordinary, specific <a>conditional</a>) cause the occurrence of the corresponding degree of Bill's anger. (Section 17.4.1)
@@ -2129,6 +1989,7 @@
   InstanceOf: ""
   Alias:
     - comparative construction
+    - comparative
   SubtypeOf:
     - adverbial clause construction [cxn]
   AssociatedTo: []
@@ -2155,7 +2016,8 @@
   SubtypeOf:
     - pronoun [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>pronoun</a> expressing a <a>comparative referent</a>. <i>Example</i>: in <i>The boy runs as fast as anyone in his class</i>, <i>anyone</i> is a comparative pronoun expressing a hypothetical referent selected from the class representing the standard to which the boy's running is being compared. (Section 3.5)
 
 - Id: comparative referent [inf]
   Type: inf
@@ -2164,16 +2026,6 @@
     - comparative referent
   SubtypeOf:
     - nonspecific referent [inf]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: comparative referent [inf] / pronoun [cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - comparative referent/pronoun
-    - comparative
-  SubtypeOf: []
   AssociatedTo: []
   Definition: >-
     an unspecified <a>referent</a> occurring in the <a>standard</a> of comparison in a <a>comparative construction</a>. <i>Example</i>: in <i>The boy runs as fast as anyone in his class</i>, <i>anyone</i> is a comparative pronoun expressing a hypothetical referent selected from the class representing the standard to which the boy's running is being compared. (Section 3.5)
@@ -2378,72 +2230,55 @@
 
 - Id: concessive conditional construction [cxn]
   Type: cxn
-  InstanceOf: concessive conditional relation [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - concessive conditional construction
     - conditional concessive construction
   SubtypeOf:
     - adverbial clause construction [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the construction that expresses a <a>concessive conditional relation</a>. <i>Example</i>: <i>However much advice you give him, he does exactly what he wants to do</i> is an instance of the concessive conditional relation and construction -- the <a>protasis</a> <i>However much advice you give him</i> introduces a scalar model of your giving him a full range of amounts of advice; and the <a>apodosis</a> <i>he does exactly what he wants to do</i> describes the event that occurs or would occur under any of those conditions. The speaker has a neutral epistemic stance toward the range of events associated with the scalar model. The apodosis has an unexpected causal relation with respect to the set of events that make up the protasis. A concessive conditional may express a <a content causal relation>content</a>, <a epistemic causal relation>epistemic</a>, or <a>speech act causal relation</a>. (Section 17.3.3)
 
 - Id: concessive conditional relation [sem]
   Type: sem
-  InstanceOf: concessive conditional relation [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - concessive conditional relation
     - conditional concessive relation
+    - concessive conditional
   SubtypeOf:
     - semantic relation (FN-Br) [sem]
   AssociatedTo:
     - neutral epistemic stance [sem]
     - concessive relation [sem]
     - conditional relation [sem]
-  Definition: ""
-
-- Id: concessive conditional relation [sem] / construction [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - concessive conditional relation/construction
-    - concessive conditional
-    - conditional concessive
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>causal relation</a> between a set of <a>events</a> that are associated with a <a>scalar model</a> on the one hand, and another event, such that the other event would occur under the entire range of conditions described in the scalar model associated with the first set of events; and the construction that expresses that relation. <i>Example</i>: <i>However much advice you give him, he does exactly what he wants to do</i> is an instance of the concessive conditional relation and construction -- the <a>protasis</a> <i>However much advice you give him</i> introduces a scalar model of your giving him a full range of amounts of advice; and the <a>apodosis</a> <i>he does exactly what he wants to do</i> describes the event that occurs or would occur under any of those conditions. The speaker has a neutral epistemic stance toward the range of events associated with the scalar model. The apodosis has an unexpected causal relation with respect to the set of events that make up the protasis. A concessive conditional may express a <a content causal relation>content</a>, <a epistemic causal relation>epistemic</a>, or <a>speech act causal relation</a>. (Section 17.3.3)
+    a <a>causal relation</a> between a set of <a>events</a> that are associated with a <a>scalar model</a> on the one hand, and another event, such that the other event would occur under the entire range of conditions described in the scalar model associated with the first set of events. <i>Example</i>: <i>However much advice you give him, he does exactly what he wants to do</i> is an instance of the concessive conditional relation and construction -- the <a>protasis</a> <i>However much advice you give him</i> introduces a scalar model of your giving him a full range of amounts of advice; and the <a>apodosis</a> <i>he does exactly what he wants to do</i> describes the event that occurs or would occur under any of those conditions. The speaker has a neutral epistemic stance toward the range of events associated with the scalar model. The apodosis has an unexpected causal relation with respect to the set of events that make up the protasis. A concessive conditional may express a <a content causal relation>content</a>, <a epistemic causal relation>epistemic</a>, or <a>speech act causal relation</a>. (Section 17.3.3)
 
 - Id: concessive construction [cxn]
   Type: cxn
-  InstanceOf: concessive relation [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - concessive construction
   SubtypeOf:
     - adverbial clause construction [cxn]
   AssociatedTo:
     - adversative coordination [cxn]
-  Definition: ""
+  Definition: >-
+    the construction that expresses a <a>concessive relation</a>.. <i>Example</i>: <i>Although it was raining, I went out</i> is an instance of a concessive relation and construction: the expected causal relation is that rain would lead to my staying in; but in fact I went out. The speaker has a <a>positive epistemic stance</a> toward the concessive construction. A concessive may express a <a content causal relation>content</a>, <a epistemic causal relation>epistemic</a>, or <a>speech act causal relation</a>. (Section 17.3.2)
 
 - Id: concessive relation [sem]
   Type: sem
-  InstanceOf: concessive relation [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - concessive relation
+    - concessive
   SubtypeOf:
     - semantic relation (FN-Br) [sem]
   AssociatedTo:
     - positive epistemic stance [sem]
     - unexpected co-occurrence [sem]
-  Definition: ""
-
-- Id: concessive relation [sem] / construction [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - concessive relation/construction
-    - concessive
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
     a relation between two <a>events</a> such that there is an expected <a>causal relation</a> between the two events, but the opposite of the second event, expressed in the <a>apodosis</a>, unexpectedly occurs. <i>Example</i>: <i>Although it was raining, I went out</i> is an instance of a concessive relation and construction: the expected causal relation is that rain would lead to my staying in; but in fact I went out. The speaker has a <a>positive epistemic stance</a> toward the concessive construction. A concessive may express a <a content causal relation>content</a>, <a epistemic causal relation>epistemic</a>, or <a>speech act causal relation</a>. (Section 17.3.2)
 
@@ -2460,13 +2295,14 @@
 
 - Id: conditional construction [cxn]
   Type: cxn
-  InstanceOf: conditional relation [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - conditional construction
   SubtypeOf:
     - adverbial clause construction [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>construction</a> that expresses a <a>conditional relation</a>. <i>Example</i>: <i>If you press this button, the door will open</i> is an instance of the conditional relation and construction. The causally antecedent proposition is the <a>protasis</a>, and the causally consequent proposition is the <a>apodosis</a>. A conditional may express a <a content causal relation>content</a>, <a epistemic causal relation>epistemic</a> or <a>speech act causal relation</a>. (Section 17.3.1)
 
 - Id: conditional deranking system [str]
   Type: str
@@ -2498,55 +2334,37 @@
 
 - Id: conditional pronoun [cxn]
   Type: cxn
-  InstanceOf: conditional referent [inf] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - conditional pronoun
   SubtypeOf:
     - pronoun [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a conditional pronoun that expresses a <a>conditional referent</a>. <i>Example</i>: in <i>If you hear <b>anything</b>, tell me</i>, <i>anything</i> is a conditional pronoun expressing a referent that is found only in the hypothetical world introduced by the protasis of the conditional construction. (Section 3.5)
 
 - Id: conditional referent [inf]
   Type: inf
-  InstanceOf: conditional referent [inf] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - conditional referent
   SubtypeOf:
     - nonspecific referent [inf]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: conditional referent [inf] / pronoun [cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - conditional referent/pronoun
-    - conditional
-  SubtypeOf: []
   AssociatedTo: []
   Definition: >-
     an unspecified <a>referent</a> in the <a>protasis</a> in a <a>conditional construction</a>. <i>Example</i>: in <i>If you hear <b>anything</b>, tell me</i>, <i>anything</i> is a conditional pronoun expressing a referent that is found only in the hypothetical world introduced by the protasis of the conditional construction. (Section 3.5)
 
 - Id: conditional relation [sem]
   Type: sem
-  InstanceOf: conditional relation [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - conditional relation
+    - conditional
   SubtypeOf:
     - semantic relation (FN-Br) [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: conditional relation [sem] / construction [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - conditional relation/construction
-    - conditional
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a semantic relation between two <a>events</a> that involves a logical material implication relation between their corresponding <a>propositions</a>, some type of <a>causal relation</a> between the corresponding <a>events</a>, and non-positive <a>epistemic stance</a>; and the <a>construction</a> that expresses that relation. <i>Example</i>: <i>If you press this button, the door will open</i> is an instance of the conditional relation and construction. The causally antecedent proposition is the <a>protasis</a>, and the causally consequent proposition is the <a>apodosis</a>. A conditional may express a <a content causal relation>content</a>, <a epistemic causal relation>epistemic</a> or <a>speech act causal relation</a>. (Section 17.3.1)
+    a semantic relation between two <a>events</a> that involves a logical material implication relation between their corresponding <a>propositions</a>, some type of <a>causal relation</a> between the corresponding <a>events</a>, and non-positive <a>epistemic stance</a>. <i>Example</i>: <i>If you press this button, the door will open</i> is an instance of the conditional relation and construction. The causally antecedent proposition is the <a>protasis</a>, and the causally consequent proposition is the <a>apodosis</a>. A conditional may express a <a content causal relation>content</a>, <a epistemic causal relation>epistemic</a> or <a>speech act causal relation</a>. (Section 17.3.1)
 
 - Id: conjoined comparative [str]
   Type: str
@@ -2637,34 +2455,26 @@
 
 - Id: contact by impact event [sem]
   Type: sem
-  InstanceOf: contact by impact event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - contact by impact event
+    - contact by impact
   SubtypeOf:
     - event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: contact by impact event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - contact by impact event/verb
-    - contact by impact
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> describing contact by impact; and the <a>verb</a> expressing such an event. <i>Example</i>: hitting is a contact by impact event, and <i>hit</i> is a contact by impact verb. (Section 7.3.2)
+    an <a>event</a> describing contact by impact. <i>Example</i>: hitting is a contact by impact event. (Section 7.3.2)
 
 - Id: contact by impact verb [cxn]
   Type: cxn
-  InstanceOf: contact by impact event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - contact by impact verb
   SubtypeOf:
     - verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing a <a>contact by impact event</a>. <i>Example</i>: hitting is a contact by impact event, and <i>hit</i> is a contact by impact verb. (Section 7.3.2)
 
 - Id: container term [cxn]
   Type: cxn
@@ -2679,7 +2489,7 @@
 
 - Id: content causal construction [cxn]
   Type: cxn
-  InstanceOf: content causal relation [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - content causal construction
   SubtypeOf:
@@ -2688,28 +2498,19 @@
     - concessive construction [cxn]
     - concessive conditional construction [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the construction expressing a <a>content causal relation</a>. <i>Example</i>: in <i>If you press this button, the door will open</i>, there is a content causal relation between the event of your pressing the button and the event of the door opening. (Section 17.3.1)
 
 - Id: content causal relation [sem]
   Type: sem
-  InstanceOf: content causal relation [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - content causal relation
   SubtypeOf:
     - causal [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: content causal relation [sem] / construction [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - content causal relation/construction
-    - content causal
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    the semantic relation in a <a>conditional</a>, <a>causal</a>, <a>concessive</a>, or <a>conditional concessive construction</a> that expresses a <a>causal relation</a> between events in the world; and the construction expressing that relation. <i>Example</i>: in <i>If you press this button, the door will open</i>, there is a content causal relation between the event of your pressing the button and the event of the door opening. A content causal relation contrasts with an <a>epistemic causal relation</a> or a <a>speech act causal relation</a>. (Section 17.3.1)
+    the semantic relation in a <a>conditional</a>, <a>causal</a>, <a>concessive</a>, or <a>conditional concessive construction</a> that expresses a <a>causal relation</a> between events in the world. <i>Example</i>: in <i>If you press this button, the door will open</i>, there is a content causal relation between the event of your pressing the button and the event of the door opening. A content causal relation contrasts with an <a>epistemic causal relation</a> or a <a>speech act causal relation</a>. (Section 17.3.1)
 
 - Id: contextual [sem]
   Type: sem
@@ -2761,34 +2562,25 @@
 
 - Id: controlled activity [sem]
   Type: sem
-  InstanceOf: controlled activity [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - controlled activity
   SubtypeOf:
     - event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: controlled activity [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - controlled activity/predicate
-    - controlled
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    the <a>event</a> class of agentive processes, and the <a>predicates</a> that express events in this class. <i>Example</i>: running is a controlled activity event, and <i>run</i> is a controlled activity predicate. (Section 6.3.3)
+    the <a>event</a> class of agentive processes. <i>Example</i>: running is a controlled activity event. (Section 6.3.3)
 
 - Id: controlled predicate [cxn]
   Type: cxn
-  InstanceOf: controlled activity [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - controlled predicate
   SubtypeOf:
     - predicate [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>predicates</a> that express events in the <a>controlled activity</a> class. <i>Example</i>: running is a controlled activity event, and <i>run</i> is a controlled activity predicate. (Section 6.3.3)
 
 - Id: controller [str]
   Type: str
@@ -3017,35 +2809,26 @@
 
 - Id: damage event [sem]
   Type: sem
-  InstanceOf: damage event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - damage event
   SubtypeOf:
     - event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: damage event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - damage event/verb
-    - damage
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> describing material damage to an <a>object</a>; and the <a>verb</a> expressing such an event. <i>Example</i>: scratching something is a damage event, and <i>scratch</i> is a damage verb. (Section 7.3.2)
+    an <a>event</a> describing material damage to an <a>object</a>. <i>Example</i>: scratching something is a damage event. (Section 7.3.2)
 
 - Id: damage verb [cxn]
   Type: cxn
-  InstanceOf: damage event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - damage verb
   SubtypeOf:
     - manner verb [cxn]
     - result verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing a <a>damage event</a>. <i>Example</i>: scratching something is a damage event, and <i>scratch</i> is a damage verb. (Section 7.3.2)
 
 - Id: declarative [cxn]
   Type: cxn
@@ -3055,17 +2838,8 @@
   SubtypeOf:
     - speech acts [cxn]
   AssociatedTo: []
-  Definition: ""
-
-- Id: declarative [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - declarative
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>speech act</a> which simply asserts its <a>propositional content</a>, and the <a>construction</a> that expresses this speech act. <i>Example</i>: The English sentence <i>Sandra picked up the children</i> is an instance of a declarative speech act. The declarative is the most common speech act construction, and is considered the default speech act construction. (Section 12.1)
+    the <a>construction</a> that expresses a <a>declarative</a> speech act. <i>Example</i>: The English sentence <i>Sandra picked up the children</i> is an instance of a declarative speech act. The declarative is the most common speech act construction, and is considered the default speech act construction. (Section 12.1)
 
 - Id: declarative [inf]
   Type: inf
@@ -3075,7 +2849,8 @@
   SubtypeOf:
     - speech acts [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>speech act</a> which simply asserts its <a>propositional content</a>. <i>Example</i>: The English sentence <i>Sandra picked up the children</i> is an instance of a declarative speech act. (Section 12.1)
 
 - Id: declarative negation construction [cxn]
   Type: cxn
@@ -3092,30 +2867,22 @@
 
 - Id: definite article [cxn]
   Type: cxn
-  InstanceOf: definite pronoun/article [cxn]
+  InstanceOf: ""
   Alias:
     - definite article
   SubtypeOf:
     - article [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    this term is applied to <a>referring phrases</a> -- <a>pronouns</a> and <a>articles</a> combined with <a>nouns</a> -- that are associated with the top end of the <a>information status</a> continuum, where the identity of the referent is already known to both speaker and hearer. This includes <a>active</a>, <a>semi-active</a>, <a>inactive</a>, and <a>inferrable</a> referents. <i>Example</i>: <i>the glass bowl</i> is an example of a definite referring phrase, used in a context where the individual glass bowl in question is identifiable by both speaker and hearer (Table 3.4, Section 3.3.1)
 
 - Id: definite pronoun [cxn]
   Type: cxn
-  InstanceOf: definite pronoun/article [cxn]
+  InstanceOf: ""
   Alias:
     - definite pronoun
   SubtypeOf:
     - pronoun [cxn]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: definite pronoun/article [cxn]
-  Type: cxn
-  InstanceOf: ""
-  Alias:
-    - definite pronoun/article
-  SubtypeOf: []
   AssociatedTo: []
   Definition: >-
     this term is applied to <a>referring phrases</a> -- <a>pronouns</a> and <a>articles</a> combined with <a>nouns</a> -- that are associated with the top end of the <a>information status</a> continuum, where the identity of the referent is already known to both speaker and hearer. This includes <a>active</a>, <a>semi-active</a>, <a>inactive</a>, and <a>inferrable</a> referents. <i>Example</i>: <i>the glass bowl</i> is an example of a definite referring phrase, used in a context where the individual glass bowl in question is identifiable by both speaker and hearer (Table 3.4, Section 3.3.1)
@@ -3347,35 +3114,27 @@
 
 - Id: desiderative event [sem]
   Type: sem
-  InstanceOf: desiderative event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - desiderative event
+    - desiderative
   SubtypeOf:
     - event [sem]
   AssociatedTo:
     - dependent time reference [sem]
-  Definition: ""
-
-- Id: desiderative event [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - desiderative event/predicate
-    - desiderative
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> that expresses a desire toward the realization of a future event that is expressed by the complement; and the <a>predicate</a> that expresses the event. <i>Example</i>: in <i>Meagan wants to climb Mt. Baldy on Saturday, wants</i> denotes a desiderative event. Noonan (2007:135) includes intending events in the category of desiderative events. (Section 18.2.2)
+    an <a>event</a> that expresses a desire toward the realization of a future event that is expressed by the complement. <i>Example</i>: in <i>Meagan wants to climb Mt. Baldy on Saturday, wants</i> denotes a desiderative event. Noonan (2007:135) includes intending events in the category of desiderative events. (Section 18.2.2)
 
 - Id: desiderative predicate [cxn]
   Type: cxn
-  InstanceOf: desiderative event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - desiderative predicate
   SubtypeOf:
     - predicate [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>predicate</a> that expresses a <a>desiderative event</a>. <i>Example</i>: in <i>Meagan wants to climb Mt. Baldy on Saturday, wants</i> denotes a desiderative event. Noonan (2007:135) includes intending events in the category of desiderative events. (Section 18.2.2)
 
 - Id: detached (topic phrase) [str]
   Type: str
@@ -3453,31 +3212,22 @@
 
 - Id: direct negation pronoun [cxn]
   Type: cxn
-  InstanceOf: direct negation referent [inf] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - direct negation pronoun
   SubtypeOf:
     - pronoun [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>pronoun</a> that expresses a <a>direct negation referent</a>. <i>Example</i>: in <i>I noticed nothing</i>, <i>nothing</i> is a direct negation pronoun expressing a referent found only in the negative alternative world to the real world. (Section 3.5)
 
 - Id: direct negation referent [inf]
   Type: inf
-  InstanceOf: direct negation referent [inf] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - direct negation referent
   SubtypeOf:
     - nonspecific referent [inf]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: direct negation referent [inf] / pronoun [cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - direct negation referent/pronoun
-    - direct negation
-  SubtypeOf: []
   AssociatedTo: []
   Definition: >-
     an unspecified <a>referent</a> which is in the scope of <a>negation</a> in the same <a>clause</a>. <i>Example</i>: in <i>I noticed nothing</i>, <i>nothing</i> is a direct negation pronoun expressing a referent found only in the negative alternative world to the real world. (Section 3.5)
@@ -3806,34 +3556,25 @@
 
 - Id: emotion event [sem]
   Type: sem
-  InstanceOf: emotion event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - emotion event
   SubtypeOf:
     - experiential event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: emotion event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - emotion event/verb
-    - emotion
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>experiential event</a> involving an <a>experiencer</a>'s emotions directed toward a <a>stimulus</a>; and a <a>verb</a> that expresses such an event. <i>Example</i>: <i>He fears dogs</i> is an example of an emotion event, and <i>fear</i> is the emotion verb. (Section 7.4)
+    an <a>experiential event</a> involving an <a>experiencer</a>'s emotions directed toward a <a>stimulus</a>. <i>Example</i>: <i>He fears dogs</i> is an example of an emotion event. (Section 7.4)
 
 - Id: emotion verb [cxn]
   Type: cxn
-  InstanceOf: emotion event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - emotion verb
   SubtypeOf:
     - experiential verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>verb</a> that expresses an <a>emotion event</a>. <i>Example</i>: <i>He fears dogs</i> is an example of an emotion event, and <i>fear</i> is the emotion verb. (Section 7.4)
 
 - Id: encoding strategy [str]
   Type: str
@@ -3872,37 +3613,29 @@
 
 - Id: entity-central [cxn]
   Type: cxn
-  InstanceOf: entity-central [inf/cxn]
+  InstanceOf: ""
   Alias:
     - entity-central
   SubtypeOf:
     - thetic [cxn]
   AssociatedTo: []
-  Definition: ""
-
-- Id: entity-central [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - entity-central
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a type of <a>thetic</a> in which the most important new information being presented is the identity of the <a>object</a> (entity); and the <a>construction</a> that expresses that information packaging. <i>Example</i>: <i>There's a snake in the kitchen sink</i> is an instance of an entity-central thetic construction, where the primary new information being presented is the snake. (Sections 10.1.2, <b>11.3.1</b>)
+    the <a>construction</a> that expresses an <a>entity-central</a> information packaging. <i>Example</i>: <i>There's a snake in the kitchen sink</i> is an instance of an entity-central thetic construction, where the primary new information being presented is the snake. (Sections 10.1.2, <b>11.3.1</b>)
 
 - Id: entity-central [inf]
   Type: inf
-  InstanceOf: entity-central [inf/cxn]
+  InstanceOf: ""
   Alias:
     - entity-central
   SubtypeOf:
     - thetic [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a type of <a>thetic</a> in which the most important new information being presented is the identity of the <a>object</a> (entity). <i>Example</i>: <i>There's a snake in the kitchen sink</i> is an instance of an entity-central thetic construction, where the primary new information being presented is the snake. (Sections 10.1.2, <b>11.3.1</b>)
 
 - Id: epistemic causal construction [cxn]
   Type: cxn
-  InstanceOf: epistemic causal relation [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - epistemic causal construction
   SubtypeOf:
@@ -3911,28 +3644,19 @@
     - concessive construction [cxn]
     - concessive conditional construction [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the construction expressing an <a>epistemic causal relation</a>. <i>Example</i>: in <i>If Professor Smith's door is closed, then she is not on campus</i>, there is an epistemic causal relation between the fact that Professor Smith's office door is closed and the inference that she is not on campus. (Section 17.3.1)
 
 - Id: epistemic causal relation [sem]
   Type: sem
-  InstanceOf: epistemic causal relation [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - epistemic causal relation
   SubtypeOf:
     - causal [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: epistemic causal relation [sem] / construction [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - epistemic causal relation/construction
-    - epistemic causal
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    the semantic relation in a <a>conditional</a>, <a>causal</a>, <a>concessive</a>, or <a>conditional concessive construction</a> that expresses an epistemic inferential relation between two propositions; and the construction expressing that relation. <i>Example</i>: in <i>If Professor Smith's door is closed, then she is not on campus</i>, there is an epistemic causal relation between the fact that Professor Smith's office door is closed and the inference that she is not on campus. An epistemic causal relation contrasts with a <a>content causal relation</a> and a <a>speech act causal relation</a>. (Section 17.3.1)
+    the semantic relation in a <a>conditional</a>, <a>causal</a>, <a>concessive</a>, or <a>conditional concessive construction</a> that expresses an epistemic inferential relation between two propositions. <i>Example</i>: in <i>If Professor Smith's door is closed, then she is not on campus</i>, there is an epistemic causal relation between the fact that Professor Smith's office door is closed and the inference that she is not on campus. An epistemic causal relation contrasts with a <a>content causal relation</a> and a <a>speech act causal relation</a>. (Section 17.3.1)
 
 - Id: epistemic modality [sem]
   Type: sem
@@ -3974,7 +3698,7 @@
 
 - Id: equational [cxn]
   Type: cxn
-  InstanceOf: equational [inf/cxn]
+  InstanceOf: ""
   Alias:
     - equational
   SubtypeOf:
@@ -3982,27 +3706,19 @@
     - nonpredicational clauses [cxn]
   AssociatedTo:
     - predicate nominal construction [cxn]
-  Definition: ""
-
-- Id: equational [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - equational
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a type of <a>identificational information packaging</a> in which two <a>referents</a> that the hearer assumed were different individuals are asserted to be, in fact, one and the same individual; and the <a>construction</a> that expresses that information packaging. <i>Example</i>: in <i>The Morning Star is the Evening Star</i>, it is asserted that two celestial objects that were once thought to be distinct objects (and given distinct names) are one and the same, namely the planet Venus. (Section 10.1.2)
+    the <a>construction</a> that expresses an <a>equational</a> information packaging. <i>Example</i>: in <i>The Morning Star is the Evening Star</i>, it is asserted that two celestial objects that were once thought to be distinct objects (and given distinct names) are one and the same, namely the planet Venus. (Section 10.1.2)
 
 - Id: equational [inf]
   Type: inf
-  InstanceOf: equational [inf/cxn]
+  InstanceOf: ""
   Alias:
     - equational
   SubtypeOf:
     - identificational [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a type of <a>identificational information packaging</a> in which two <a>referents</a> that the hearer assumed were different individuals are asserted to be, in fact, one and the same individual. <i>Example</i>: in <i>The Morning Star is the Evening Star</i>, it is asserted that two celestial objects that were once thought to be distinct objects (and given distinct names) are one and the same, namely the planet Venus. (Section 10.1.2)
 
 - Id: equative construction [cxn]
   Type: cxn
@@ -4055,35 +3771,27 @@
 
 - Id: evaluative event [sem]
   Type: sem
-  InstanceOf: evaluative event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - evaluative event
+    - evaluative
   SubtypeOf:
     - event [sem]
   AssociatedTo:
     - independent time reference [sem]
-  Definition: ""
-
-- Id: evaluative event [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - evaluative event/predicate
-    - evaluative
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> in which an evaluative judgment is made about the truth of the <a>proposition</a> expressed in its <a>complement</a>; and a <a>predicate</a> expressing this event. Evaluative events may assume different <a>epistemic stances</a> toward the proposition expressed in their complement. <a>Commentative events</a> assume a positive epistemic stance; <a>hoping</a> and <a>fearing events</a> assume a <a>neutral epistemic stance</a>; and <a>wishing events</a> assume a <a>negative epistemic stance</a>. (Section 18.2.2)
+    an <a>event</a> in which an evaluative judgment is made about the truth of the <a>proposition</a> expressed in its <a>complement</a>. Evaluative events may assume different <a>epistemic stances</a> toward the proposition expressed in their complement. <a>Commentative events</a> assume a positive epistemic stance; <a>hoping</a> and <a>fearing events</a> assume a <a>neutral epistemic stance</a>; and <a>wishing events</a> assume a <a>negative epistemic stance</a>. (Section 18.2.2)
 
 - Id: evaluative predicate [cxn]
   Type: cxn
-  InstanceOf: evaluative event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - evaluative predicate
   SubtypeOf:
     - complement-taking predicate [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>predicate</a> expressing an <a>evaluative event</a>. (Section 18.2.2)
 
 - Id: event [sem]
   Type: sem
@@ -4103,33 +3811,25 @@
 
 - Id: event-central [cxn]
   Type: cxn
-  InstanceOf: event-central [inf/cxn]
+  InstanceOf: ""
   Alias:
     - event-central
   SubtypeOf:
     - thetic [cxn]
   AssociatedTo: []
-  Definition: ""
-
-- Id: event-central [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - event-central
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a type of <a>thetic</a> in which the more important new information being presented is the <a>event</a> reported; and the <a>construction</a> that expresses that information packaging. <i>Example</i>: in <i>The PHONE's ringing</i>, the most important new information is the ringing of the phone, not the existence of the phone. (Sections 10.1.2, <b>11.3.1</b>)
+    a <a>construction</a> that expresses an <a>event-central</a> information packaging. <i>Example</i>: in <i>The PHONE's ringing</i>, the most important new information is the ringing of the phone, not the existence of the phone. (Sections 10.1.2, <b>11.3.1</b>)
 
 - Id: event-central [inf]
   Type: inf
-  InstanceOf: event-central [inf/cxn]
+  InstanceOf: ""
   Alias:
     - event-central
   SubtypeOf:
     - thetic [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a type of <a>thetic</a> in which the more important new information being presented is the <a>event</a> reported. <i>Example</i>: in <i>The PHONE's ringing</i>, the most important new information is the ringing of the phone, not the existence of the phone. (Sections 10.1.2, <b>11.3.1</b>)
 
 - Id: event-oriented [sem]
   Type: sem
@@ -4181,33 +3881,25 @@
 
 - Id: exclamative [cxn]
   Type: cxn
-  InstanceOf: exclamative [inf/cxn]
+  InstanceOf: ""
   Alias:
     - exclamative
   SubtypeOf:
     - speech acts [cxn]
   AssociatedTo: []
-  Definition: ""
-
-- Id: exclamative [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - exclamative
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>speech act</a> which expresses a strong emotional reaction to the <a>propositional content</a> that it conveys; and the <a>construction</a> that expresses this speech act. More precisely, the exclamative speech act expresses the speaker's surprise toward the <a>degree</a> of a scalar <a>property</a> contained in the propositional content of the speech act; the rest of the propositional content consists of a <a>presupposed open proposition</a>. <i>Example</i>: <i>What a beautiful house!</i> is an instance of an English exclamative construction. (Sections 12.1, 12.5)
+    a <a>speech act</a> which expresses a strong emotional reaction to the <a>propositional content</a> that it conveys. More precisely, the exclamative speech act expresses the speaker's surprise toward the <a>degree</a> of a scalar <a>property</a> contained in the propositional content of the speech act; the rest of the propositional content consists of a <a>presupposed open proposition</a>. <i>Example</i>: <i>What a beautiful house!</i> is an instance of an English exclamative construction. (Sections 12.1, 12.5)
 
 - Id: exclamative [inf]
   Type: inf
-  InstanceOf: exclamative [inf/cxn]
+  InstanceOf: ""
   Alias:
     - exclamative
   SubtypeOf:
     - speech acts [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>construction</a> that expresses an <a>exclamative</a> speech act. <i>Example</i>: <i>What a beautiful house!</i> is an instance of an English exclamative construction. (Sections 12.1, 12.5)
 
 - Id: exclusive disjunctive coordination [cxn]
   Type: cxn
@@ -4285,35 +3977,26 @@
 
 - Id: experience event [sem]
   Type: sem
-  InstanceOf: experience event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - experience event
   SubtypeOf:
     - experiential event [sem]
   AssociatedTo:
     - experiential verb [cxn]
-  Definition: ""
-
-- Id: experience event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - experience event/verb
-    - experience
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>experiential event</a> which describes the state holding between an <a>experiencer</a> directing her/his attention to a <a>stimulus</a> and the stimulus altering the mental state of the experiencer (or the inception of such a state); and a <a>verb</a> that expresses such an event. <i>Example</i>: <i>I saw the dog</i> is an instance of an experience event, and <i>see</i> is an experience verb. (Section 7.4)
+    an <a>experiential event</a> which describes the state holding between an <a>experiencer</a> directing her/his attention to a <a>stimulus</a> and the stimulus altering the mental state of the experiencer (or the inception of such a state). <i>Example</i>: <i>I saw the dog</i> is an instance of an experience event. (Section 7.4)
 
 - Id: experience verb [cxn]
   Type: cxn
-  InstanceOf: experience event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - experience verb
   SubtypeOf:
     - experiential verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>verb</a> that expresses an <a>experience event</a>. <i>Example</i>: <i>I saw the dog</i> is an instance of an experience event, and <i>see</i> is an experience verb. (Section 7.4)
 
 - Id: experiencer [sem]
   Type: sem
@@ -4354,24 +4037,14 @@
 
 - Id: experiential event [sem]
   Type: sem
-  InstanceOf: experiential event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - experiential event
   SubtypeOf:
     - event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: experiential event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - experiential event/verb
-    - experiential
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> that involves a human internal mental or bodily experience; and a <a>verb</a> that expresses such an event. Experiential events include <a>perception events</a>, <a>cognition events</a>, <a>emotion events</a>, and <a sensation event>(bodily) sensation events</a>; <a>ingestion events</a> also exhibit some semantic similarities to experiential events. (Sections 6.1.2, <b>7.4</b>)
+    an <a>event</a> that involves a human internal mental or bodily experience. (Sections 6.1.2, <b>7.4</b>)
 
 - Id: experiential verb [cxn]
   Type: cxn
@@ -4382,7 +4055,8 @@
     - verb [cxn]
   AssociatedTo:
     - experiential construction [cxn]
-  Definition: ""
+  Definition: >-
+    a <a>verb</a> that expresses an <a>experiential event</a>. Experiential events include <a>perception events</a>, <a>cognition events</a>, <a>emotion events</a>, and <a sensation event>(bodily) sensation events</a>; <a>ingestion events</a> also exhibit some semantic similarities to experiential events. (Sections 6.1.2, <b>7.4</b>)
 
 - Id: expertum [sem]
   Type: sem
@@ -4472,34 +4146,25 @@
 
 - Id: extroverted event [sem]
   Type: sem
-  InstanceOf: extroverted event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - extroverted event
   SubtypeOf:
     - event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: extroverted event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - extroverted event/verb
-    - extroverted
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an event not normally performed on oneself or on each other; and a <a>verb</a> expressing such an event. <i>Examples</i>: seeing something vs. oneself, or loving someone vs. oneself (or even each other), are instances of extroverted events, and <i>see</i> and <i>love</i> are extroverted verbs. (Section 7.2)
+    an event not normally performed on oneself or on each other. <i>Examples</i>: seeing something vs. oneself, or loving someone vs. oneself (or even each other), are instances of extroverted events, and <i>see</i> and <i>love</i> are extroverted verbs. (Section 7.2)
 
 - Id: extroverted verb [cxn]
   Type: cxn
-  InstanceOf: extroverted event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - extroverted verb
   SubtypeOf:
     - verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>verb</a> expressing an <a>extroverted event</a>. <i>Examples</i>: seeing something vs. oneself, or loving someone vs. oneself (or even each other), are instances of extroverted events, and <i>see</i> and <i>love</i> are extroverted verbs. (Section 7.2)
 
 - Id: factive event [sem]
   Type: sem
@@ -4525,35 +4190,26 @@
 
 - Id: fearing event [sem]
   Type: sem
-  InstanceOf: fearing event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - fearing event
   SubtypeOf:
     - evaluative event [sem]
   AssociatedTo:
     - neutral epistemic stance [sem]
-  Definition: ""
-
-- Id: fearing event [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - fearing event/predicate
-    - fearing
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>evaluative event</a> in which a negative evaluative judgment about a <a>proposition</a> expressed by the <a>complement</a> of the commentative event is made, and there is a <a>neutral epistemic stance</a> by the speaker toward the proposition; and the <a>predicate</a> expressing this event. <i>Example</i>: in <i>Jill fears that Donald has won the election</i>, the commentative predicate <i>fears</i> expresses Jill's evaluation of Donald's winning the election, and also presupposes that the speaker does not know whether Donald has won the election. (Section 18.2.2)
+    an <a>evaluative event</a> in which a negative evaluative judgment about a <a>proposition</a> expressed by the <a>complement</a> of the commentative event is made, and there is a <a>neutral epistemic stance</a> by the speaker toward the proposition. <i>Example</i>: in <i>Jill fears that Donald has won the election</i>, the commentative predicate <i>fears</i> expresses Jill's evaluation of Donald's winning the election, and also presupposes that the speaker does not know whether Donald has won the election. (Section 18.2.2)
 
 - Id: fearing predicate [cxn]
   Type: cxn
-  InstanceOf: fearing event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - fearing predicate
   SubtypeOf:
     - evaluative predicate [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>predicate</a> expressing a <a>fearing event</a>. <i>Example</i>: in <i>Jill fears that Donald has won the election</i>, the commentative predicate <i>fears</i> expresses Jill's evaluation of Donald's winning the election, and also presupposes that the speaker does not know whether Donald has won the election. (Section 18.2.2)
 
 - Id: figure [sem]
   Type: sem
@@ -4729,31 +4385,22 @@
 
 - Id: free choice pronoun [cxn]
   Type: cxn
-  InstanceOf: free choice referent [inf] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - free choice pronoun
   SubtypeOf:
     - pronoun [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <pronoun> that expresses a <a>free choice referent</a>. <i>Example</i>: in <i>After the fall of the Wall, East Germans were free to travel anywhere</i>, <i>anywhere</i> is a free choice pronoun expressing a referent -- a place -- toward which the agent in the clause, the East Germans, is free to choose to travel. (Section 3.5)
 
 - Id: free choice referent [inf]
   Type: inf
-  InstanceOf: free choice referent [inf] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - free choice referent
   SubtypeOf:
     - nonspecific referent [inf]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: free choice referent [inf] / pronoun [cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - free choice referent/pronoun
-    - free choice
-  SubtypeOf: []
   AssociatedTo: []
   Definition: >-
     an unspecified <a>referent</a> in certain contexts, whose identity can be freely chosen without affecting the truth value of the utterance. <i>Example</i>: in <i>After the fall of the Wall, East Germans were free to travel anywhere</i>, <i>anywhere</i> is a free choice pronoun expressing a referent -- a place -- toward which the agent in the clause, the East Germans, is free to choose to travel. (Section 3.5)
@@ -4772,7 +4419,7 @@
     - concessive conditional construction [cxn]
     - concessive construction [cxn]
   Definition: >-
-    a <a>relative clause construction</a> in which the head has one of several possible <a indefinite pronoun/article>indefinite</a> functions -- that is, <a specific known referent/pronoun>specific</a>, <a>irrealis</a>, <a free choice referent/pronoun>free choice</a>, and/or <a universal pronoun>universal</a>. <i>Example</i>: in <i>Take what(ever) you like</i>, <i>what(ever) you like</i> is a free relative clause using a <a>headless strategy</a>, and in <i>Take anything you like</i>, <i>anything you like</i> is a free relative clause using an <a>overt head strategy</a>. (Section 19.4)
+    a <a>relative clause construction</a> in which the head has one of several possible <a indefinite pronoun>indefinite</a> functions -- that is, <a specific known referent>specific</a>, <a irrealis referent>irrealis</a>, <a free choice referent>free choice</a>, and/or <a universal pronoun>universal</a>. <i>Example</i>: in <i>Take what(ever) you like</i>, <i>what(ever) you like</i> is a free relative clause using a <a>headless strategy</a>, and in <i>Take anything you like</i>, <i>anything you like</i> is a free relative clause using an <a>overt head strategy</a>. (Section 19.4)
 
 - Id: function [def]
   Type: def
@@ -4894,31 +4541,23 @@
 
 - Id: generic conditional construction [cxn]
   Type: cxn
-  InstanceOf: generic conditional relation [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - generic conditional construction
   SubtypeOf:
     - conditional construction [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a construction that expresses a <a>generic conditional relation</a>. <i>Example</i>: <i>If/When/Whenever a dog starts barking, I run away</i> is an instance of a generic conditional relation and construction -- it doesn't describe a specific instance of a dog barking causing me to run away; instead, it describes a general or habitual pattern of this causal sequence of events. (Section 17.3.1)
 
 - Id: generic conditional relation [sem]
   Type: sem
-  InstanceOf: generic conditional relation [sem] / construction [cxn]
-  Alias:
-    - generic conditional relation
-  SubtypeOf:
-    - conditional relation [sem]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: generic conditional relation [sem] / construction [cxn]
-  Type: sem/cxn
   InstanceOf: ""
   Alias:
-    - generic conditional relation/construction
+    - generic conditional relation
     - generic conditional
-  SubtypeOf: []
+  SubtypeOf:
+    - conditional relation [sem]
   AssociatedTo: []
   Definition: >-
     a subtype of the conditional relation in which an event causes another event generically or habitually. <i>Example</i>: <i>If/When/Whenever a dog starts barking, I run away</i> is an instance of a generic conditional relation and construction -- it doesn't describe a specific instance of a dog barking causing me to run away; instead, it describes a general or habitual pattern of this causal sequence of events. (Section 17.3.1)
@@ -5033,35 +4672,27 @@
 
 - Id: hoping event [sem]
   Type: sem
-  InstanceOf: hoping event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - hoping event
+    - hoping
   SubtypeOf:
     - evaluative event [sem]
   AssociatedTo:
     - neutral epistemic stance [sem]
-  Definition: ""
-
-- Id: hoping event [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - hoping event/predicate
-    - hoping
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>evaluative event</a> in which a positive evaluative judgment about a <a>proposition</a> expressed by the <a>complement</a> of the commentative event is made, and there is a <a>neutral epistemic stance</a> by the speaker toward the proposition; and the predicate expressing such an event. <i>Example</i>: in <i>Jill hopes that Joe won the election</i>, the commentative predicate <i>hopes</i> expresses Jill's evaluation of Joe's winning the election, and also presupposes that the speaker does not know whether Joe has won the election. (Section 18.2.2)
+    an <a>evaluative event</a> in which a positive evaluative judgment about a <a>proposition</a> expressed by the <a>complement</a> of the commentative event is made, and there is a <a>neutral epistemic stance</a> by the speaker toward the proposition. <i>Example</i>: in <i>Jill hopes that Joe won the election</i>, the commentative predicate <i>hopes</i> expresses Jill's evaluation of Joe's winning the election, and also presupposes that the speaker does not know whether Joe has won the election. (Section 18.2.2)
 
 - Id: hoping predicate [cxn]
   Type: cxn
-  InstanceOf: hoping event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - hoping predicate
   SubtypeOf:
     - evaluative predicate [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the predicate expressing a <a>hoping event</a>. <i>Example</i>: in <i>Jill hopes that Joe won the election</i>, the commentative predicate <i>hopes</i> expresses Jill's evaluation of Joe's winning the election, and also presupposes that the speaker does not know whether Joe has won the election. (Section 18.2.2)
 
 - Id: human [sem]
   Type: sem
@@ -5129,33 +4760,25 @@
 
 - Id: identificational [cxn]
   Type: cxn
-  InstanceOf: identificational [inf/cxn]
+  InstanceOf: ""
   Alias:
     - identificational
   SubtypeOf:
     - clause [cxn]
   AssociatedTo: []
-  Definition: ""
-
-- Id: identificational [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - identificational
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    <a>information packaging</a> in which a particular piece of information (the <a>focus</a>) is equated with the <dq>open slot</dq> in a <a>presupposed open proposition</a>; and the <a>construction</a> that expresses that information packaging. The presupposed open proposition may be evoked by an alternative proposition that differs from the identificational construction by only the focus. <i>Example</i>: in <i>It was Ollie who was playing the piano</i>, the information in the identificational construction is divided into the presupposed open proposition <q>X was playing the piano</q>, and the focused information Ollie, and what is being asserted is <q>X = Ollie</q>. The term <q>focus</q> is sometimes used as a synonym for <q>identificational</q>, but this term is used differently here. (Sections 10.1.2, 11.1, <b>11.4.1</b>)
+    the <a>construction</a> that expresses a <a>identificational</a> information packaging. The presupposed open proposition may be evoked by an alternative proposition that differs from the identificational construction by only the focus. <i>Example</i>: in <i>It was Ollie who was playing the piano</i>, the information in the identificational construction is divided into the presupposed open proposition <q>X was playing the piano</q>, and the focused information Ollie, and what is being asserted is <q>X = Ollie</q>. The term <q>focus</q> is sometimes used as a synonym for <q>identificational</q>, but this term is used differently here. (Sections 10.1.2, 11.1, <b>11.4.1</b>)
 
 - Id: identificational [inf]
   Type: inf
-  InstanceOf: identificational [inf/cxn]
+  InstanceOf: ""
   Alias:
     - identificational
   SubtypeOf:
     - predication [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    <a>information packaging</a> in which a particular piece of information (the <a>focus</a>) is equated with the <dq>open slot</dq> in a <a>presupposed open proposition</a>. The presupposed open proposition may be evoked by an alternative proposition that differs from the identificational construction by only the focus. <i>Example</i>: in <i>It was Ollie who was playing the piano</i>, the information in the identificational construction is divided into the presupposed open proposition <q>X was playing the piano</q>, and the focused information Ollie, and what is being asserted is <q>X = Ollie</q>. The term <q>focus</q> is sometimes used as a synonym for <q>identificational</q>, but this term is used differently here. (Sections 10.1.2, 11.1, <b>11.4.1</b>)
 
 - Id: identity statements [def]
   Type: def
@@ -5184,7 +4807,7 @@
 
 - Id: imperative--hortative [cxn]
   Type: cxn
-  InstanceOf: imperative--hortative [inf/cxn]
+  InstanceOf: ""
   Alias:
     - imperative--hortative
     - imperative
@@ -5192,24 +4815,12 @@
   SubtypeOf:
     - speech acts [cxn]
   AssociatedTo: []
-  Definition: ""
-
-- Id: imperative--hortative [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - imperative--hortative
-    - imperative
-    - hortative
-    - jussive
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>speech act</a> which requests that the action expressed in the propositional content of the imperative--hortative be carried out, prototypically by the addressee but possibly by other persons; and the <a>construction</a> that expresses this speech act. <i>Example</i>: <i>Dance!</i> is an example of the English imperative--hortative construction for the <a person>second person</a>, and <i>Let's dance!</i> is an example of the same for the <a person>first person</a> <a number>plural</a>. The term <q>hortative</q> is sometimes used for a first person imperative--hortative, and <q>jussive</q> for a third person imperative--hortative. A negative imperative--hortative is a <a>prohibitive</a>. (Sections 12.1, 12.4)
+    the <a>construction</a> that expresses a <a>imperative--hortative</a> speech act. <i>Example</i>: <i>Dance!</i> is an example of the English imperative--hortative construction for the <a person>second person</a>, and <i>Let's dance!</i> is an example of the same for the <a person>first person</a> <a number>plural</a>. The term <q>hortative</q> is sometimes used for a first person imperative--hortative, and <q>jussive</q> for a third person imperative--hortative. A negative imperative--hortative is a <a>prohibitive</a>. (Sections 12.1, 12.4)
 
 - Id: imperative--hortative [inf]
   Type: inf
-  InstanceOf: imperative--hortative [inf/cxn]
+  InstanceOf: ""
   Alias:
     - imperative--hortative
     - imperative
@@ -5217,7 +4828,8 @@
   SubtypeOf:
     - speech acts [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>speech act</a> which requests that the action expressed in the propositional content of the imperative--hortative be carried out, prototypically by the addressee but possibly by other persons. <i>Example</i>: <i>Dance!</i> is an example of the English imperative--hortative construction for the <a person>second person</a>, and <i>Let's dance!</i> is an example of the same for the <a person>first person</a> <a number>plural</a>. The term <q>hortative</q> is sometimes used for a first person imperative--hortative, and <q>jussive</q> for a third person imperative--hortative. A negative imperative--hortative is a <a>prohibitive</a>. (Sections 12.1, 12.4)
 
 - Id: inactive [inf]
   Type: inf
@@ -5321,33 +4933,25 @@
 
 - Id: indefinite article [cxn]
   Type: cxn
-  InstanceOf: indefinite pronoun/article [cxn]
+  InstanceOf: ""
   Alias:
     - indefinite article
   SubtypeOf:
     - article [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    this term is applied to <a>referring phrases</a> -- <a>pronouns</a> and <a>articles</a> combined with <a>nouns</a> -- that are associated with the bottom end of the <a>information status</a> continuum, where the identity of the referent is not known to speaker or hearer (or both). This includes <a>pragmatically specific</a>, <a>pragmatically nonspecific (but semantically specific)</a>, and various categories of <a>nonspecific referents</a> (see Table 3.4 and Sections 3.4--3.5). <i>Example</i>: <i>a glass bowl</i> is an example of an indefinite referring phrase, used in a context where the individual glass bowl in question is not identifiable by the hearer. (Table 3.4, Section 3.3.1)
 
 - Id: indefinite pronoun [cxn]
   Type: cxn
-  InstanceOf: indefinite pronoun/article [cxn]
+  InstanceOf: ""
   Alias:
     - indefinite pronoun
   SubtypeOf:
     - pronoun [cxn]
   AssociatedTo: []
-  Definition: ""
-
-- Id: indefinite pronoun/article [cxn]
-  Type: cxn
-  InstanceOf: ""
-  Alias:
-    - indefinite pronoun/article
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    this term is applied to <a>referring phrases</a> -- <a>pronouns</a> and <a>articles</a> combined with <a>nouns</a> -- that are associated with the bottom end of the <a>information status</a> continuum, where the identity of the referent is not known to speaker or hearer (or both). This includes <a>pragmatically specific</a>, <a>pragmatically nonspecific (but semantically specific)</a>, and various categories of <a>nonspecific</a> referents (see Table 3.4 and Sections 3.4--3.5). <i>Example</i>: <i>a glass bowl</i> is an example of an indefinite referring phrase, used in a context where the individual glass bowl in question is not identifiable by the hearer. (Table 3.4, Section 3.3.1)
+    this term is applied to <a>referring phrases</a> -- <a>pronouns</a> and <a>articles</a> combined with <a>nouns</a> -- that are associated with the bottom end of the <a>information status</a> continuum, where the identity of the referent is not known to speaker or hearer (or both). This includes <a>pragmatically specific</a>, <a>pragmatically nonspecific (but semantically specific)</a>, and various categories of <a>nonspecific referents</a> (see Table 3.4 and Sections 3.4--3.5). <i>Example</i>: <i>a glass bowl</i> is an example of an indefinite referring phrase, used in a context where the individual glass bowl in question is not identifiable by the hearer. (Table 3.4, Section 3.3.1)
 
 - Id: independent referring phrase strategy [str]
   Type: str
@@ -5455,31 +5059,22 @@
 
 - Id: indirect negation pronoun [cxn]
   Type: cxn
-  InstanceOf: indirect negation referent [inf] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - indirect negation pronoun
   SubtypeOf:
     - pronoun [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <pronoun> that expresses an <a>indirect negation referent</a>. <i>Example</i>: in <i>I don't think that anybody has seen it</i>, <i>anybody</i> is an indirect negation pronoun expressing a referent that is found only in the negated <dq>world</dq> of the speaker's beliefs. (Section 3.5)
 
 - Id: indirect negation referent [inf]
   Type: inf
-  InstanceOf: indirect negation referent [inf] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - indirect negation referent
   SubtypeOf:
     - nonspecific referent [inf]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: indirect negation referent [inf] / pronoun [cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - indirect negation referent/pronoun
-    - indirect negation
-  SubtypeOf: []
   AssociatedTo: []
   Definition: >-
     an unspecified <a>referent</a> which is in a <a>clause</a> embedded in a <a negative>negated</a> clause. <i>Example</i>: in <i>I don't think that anybody has seen it</i>, <i>anybody</i> is an indirect negation pronoun expressing a referent that is found only in the negated <dq>world</dq> of the speaker's beliefs. (Section 3.5)
@@ -5549,7 +5144,7 @@
 
 - Id: information (question) response [cxn]
   Type: cxn
-  InstanceOf: information (question) response [inf/cxn]
+  InstanceOf: ""
   Alias:
     - information (question) response
     - information question response
@@ -5557,23 +5152,12 @@
   SubtypeOf:
     - response [cxn]
   AssociatedTo: []
-  Definition: ""
-
-- Id: information (question) response [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - information (question) response
-    - information question response
-    - information response
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    the answer to an <a>information question</a>, and the <a>construction</a> that expresses that answer. <i>Example</i>: the answer to the English information question <i>Who is coming?</i> could be <i>Sandra is coming, Sandra is</i>, or just <i>Sandra</i>. (Section 12.3.3)
+    the <a>construction</a> that expresses the <a information (question) response>answer to an information question<a>. <i>Example</i>: the answer to the English information question <i>Who is coming?</i> could be <i>Sandra is coming, Sandra is</i>, or just <i>Sandra</i>. (Section 12.3.3)
 
 - Id: information (question) response [inf]
   Type: inf
-  InstanceOf: information (question) response [inf/cxn]
+  InstanceOf: ""
   Alias:
     - information (question) response
     - information question response
@@ -5581,7 +5165,8 @@
   SubtypeOf:
     - response [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the answer to an <a>information question</a>. <i>Example</i>: the answer to the English information question <i>Who is coming?</i> could be <i>Sandra is coming, Sandra is</i>, or just <i>Sandra</i>. (Section 12.3.3)
 
 - Id: information gap [inf]
   Type: inf
@@ -5610,35 +5195,25 @@
 
 - Id: information question [cxn]
   Type: cxn
-  InstanceOf: information question [inf/cxn]
+  InstanceOf: ""
   Alias:
     - information question
   SubtypeOf:
     - interrogative [cxn]
   AssociatedTo: []
-  Definition: ""
-
-- Id: information question [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - information question
-    - content question
-    - WH question
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>interrogative</a> in which the unknown piece of the <a>propositional content</a> requested of the addressee is a semantic component of the <a>proposition</a> other than its <a>polarity</a>; and the <a>construction</a> expressing this <a>function</a>. <i>Example</i>: <i>Who is coming?</i> is an instance of the English information question construction, expecting an answer identifying the person(s) who is/are coming. Information questions, unlike <a>polarity questions</a>, contain an <a>interrogative pronoun</a>. (Section 12.3.1)
+    the <a>construction</a> expressing an <a>information question</a> <a>function</a>. <i>Example</i>: <i>Who is coming?</i> is an instance of the English information question construction, expecting an answer identifying the person(s) who is/are coming. Information questions, unlike <a>polarity questions</a>, contain an <a>interrogative pronoun</a>. (Section 12.3.1)
 
 - Id: information question [inf]
   Type: inf
-  InstanceOf: information question [inf/cxn]
+  InstanceOf: ""
   Alias:
     - information question
   SubtypeOf:
     - interrogative [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    an <a>interrogative</a> in which the unknown piece of the <a>propositional content</a> requested of the addressee is a semantic component of the <a>proposition</a> other than its <a>polarity</a>. <i>Example</i>: <i>Who is coming?</i> is an instance of the English information question construction, expecting an answer identifying the person(s) who is/are coming. (Section 12.3.1)
 
 - Id: information status [inf]
   Type: inf
@@ -5655,34 +5230,25 @@
 
 - Id: ingestion event [sem]
   Type: sem
-  InstanceOf: ingestion event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - ingestion event
   SubtypeOf:
     - controlled activity [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: ingestion event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - ingestion event/verb
-    - ingestion
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> which describes the ingestion of food or drink by a person or animal, causing the food to disappear but also causing a change in the physiological state of the person/animal; and a <a>verb</a> that expresses such an event. <i>Example</i>: <i>Elena ate a lot of veggie chips</i> is an instance of an ingestion event, and <i>eat</i> is an ingestion verb. (Section 7.4)
+    an <a>event</a> which describes the ingestion of food or drink by a person or animal, causing the food to disappear but also causing a change in the physiological state of the person/animal. <i>Example</i>: <i>Elena ate a lot of veggie chips</i> is an instance of an ingestion event. (Section 7.4)
 
 - Id: ingestion verb [cxn]
   Type: cxn
-  InstanceOf: ingestion event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - ingestion verb
   SubtypeOf:
     - verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>verb</a> that expresses an <a>ingestion event</a>. <i>Example</i>: <i>Elena ate a lot of veggie chips</i> is an instance of an ingestion event, and <i>eat</i> is an ingestion verb. (Section 7.4)
 
 - Id: initiator [sem]
   Type: sem
@@ -5732,34 +5298,25 @@
 
 - Id: interaction event [sem]
   Type: sem
-  InstanceOf: interaction event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - interaction event
   SubtypeOf:
     - event [sem]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: interaction event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - interaction event/verb
-    - interaction
-  SubtypeOf: []
   AssociatedTo: []
   Definition: >-
     an <a>event</a> in which one <a>participant</a> acts on a second participant, but the change that occurs to the second participant is at least partly independent of the <a>force</a> <u>transmitted</u> by the first participant. <i>Examples</i>: interaction events include <a>pursuit events</a>, events involving two agents such as ordering someone (to do something) or supervising someone, and events involving an agent and an event, state, social institution, and so on, such as managing a budget, avoiding situations, or conforming to institutional standards. (Section 7.3)
 
 - Id: interaction verb [cxn]
   Type: cxn
-  InstanceOf: interaction event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - interaction verb
   SubtypeOf:
     - verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>verb</a> that expresses an <a>interaction event</a>. (Section 7.3)
 
 - Id: interlinear morpheme translation [def]
   Type: def
@@ -5813,34 +5370,25 @@
 
 - Id: interrogative [cxn]
   Type: cxn
-  InstanceOf: interrogative [inf/cxn]
+  InstanceOf: ""
   Alias:
     - interrogative
   SubtypeOf:
     - speech acts [cxn]
   AssociatedTo: []
-  Definition: ""
-
-- Id: interrogative [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - interrogative
-    - question
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>speech act</a> which requests information, usually of the addressee, regarding uncertain or unknown information that is part of the <a>propositional content</a> of the question; and the <a>construction</a> that expresses this speech act. Interrogatives are divided into <a>polarity questions</a>, <a>information questions</a>, and <a>alternative questions</a>. (Sections 12.1, 12.3)
+    a <a>speech act</a> which requests information, usually of the addressee, regarding uncertain or unknown information that is part of the <a>propositional content</a> of the question. Interrogatives are divided into <a>polarity questions</a>, <a>information questions</a>, and <a>alternative questions</a>. (Sections 12.1, 12.3)
 
 - Id: interrogative [inf]
   Type: inf
-  InstanceOf: interrogative [inf/cxn]
+  InstanceOf: ""
   Alias:
     - interrogative
   SubtypeOf:
     - speech acts [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>construction</a> that expresses a <a>interrogative</a> speech act. Interrogatives are divided into <a>polarity questions</a>, <a>information questions</a>, and <a>alternative questions</a>. (Sections 12.1, 12.3)
 
 - Id: interrogative complement [cxn]
   Type: cxn
@@ -5901,62 +5449,45 @@
 
 - Id: introverted event [sem]
   Type: sem
-  InstanceOf: introverted event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - introverted event
   SubtypeOf:
     - event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: introverted event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - introverted event/verb
-    - introverted
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> typically performed on oneself or by oneself, but that could be performed on someone else; and a <a>verb</a> expressing such an event. <i>Examples</i>: shaving oneself vs. shaving someone else, laying down vs. laying someone else down, or quarreling (with each other) are instances of introverted events, and <i>shave</i>, <i>lay (down)</i>, and <i>quarrel</i> are introverted verbs. (Section 7.2)
+    an <a>event</a> typically performed on oneself or by oneself, but that could be performed on someone else. <i>Examples</i>: shaving oneself vs. shaving someone else, laying down vs. laying someone else down, or quarreling (with each other) are instances of introverted events. (Section 7.2)
 
 - Id: introverted verb [cxn]
   Type: cxn
-  InstanceOf: introverted event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - introverted verb
   SubtypeOf:
     - verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>verb</a> expressing an <a>introverted event</a>. <i>Examples</i>: shaving oneself vs. shaving someone else, laying down vs. laying someone else down, or quarreling (with each other) are instances of introverted events, and <i>shave</i>, <i>lay (down)</i>, and <i>quarrel</i> are introverted verbs. (Section 7.2)
 
 - Id: irrealis pronoun [cxn]
   Type: cxn
-  InstanceOf: irrealis referent [inf] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - irrealis pronoun
   SubtypeOf:
     - pronoun [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <pronoun> that expresses an <a>irrealis referent</a>. <i>Example</i>: in <i>Visit me sometime</i>, <i>sometime</i> is an irrealis <a>pronoun</a> expressing an irrealis referent -- a time only found in the hoped-for mental space of the speaker's offer. (Section 3.5)
 
 - Id: irrealis referent [inf]
   Type: inf
-  InstanceOf: irrealis referent [inf] / pronoun [cxn]
-  Alias:
-    - irrealis referent
-  SubtypeOf:
-    - nonspecific referent [inf]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: irrealis referent [inf] / pronoun [cxn]
-  Type: inf/cxn
   InstanceOf: ""
   Alias:
-    - irrealis referent/pronoun
+    - irrealis referent
     - irrealis
-  SubtypeOf: []
+  SubtypeOf:
+    - nonspecific referent [inf]
   AssociatedTo: []
   Definition: >-
     a <a>referent</a> which is in the <dq>world</dq> or <a>mental space</a> representing a person's desire, wish, command, etc. <i>Example</i>: in <i>Visit me sometime</i>, <i>sometime</i> is an irrealis <a>pronoun</a> expressing an irrealis referent -- a time only found in the hoped-for mental space of the speaker's offer. (Section 3.5)
@@ -5974,7 +5505,7 @@
 
 - Id: killing/injuring event [sem]
   Type: sem
-  InstanceOf: killing/injuring event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - killing/injuring event
     - killing event
@@ -5982,26 +5513,12 @@
   SubtypeOf:
     - event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: killing/injuring event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - killing/injuring event/verb
-    - killing/injuring
-    - killing event/verb
-    - killing
-    - injuring event/verb
-    - injuring
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> describing the injuring of an individual, including to the point that the individual dies; and the <a>verb</a> expressing such an event. <i>Example</i>: stabbing is a killing/injuring event, and <i>stab</i> is a killing/injuring verb. (Section 7.3.2)
+    an <a>event</a> describing the injuring of an individual, including to the point that the individual dies. <i>Example</i>: stabbing is a killing/injuring event. (Section 7.3.2)
 
 - Id: killing/injuring verb [cxn]
   Type: cxn
-  InstanceOf: killing/injuring event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - killing/injuring verb
     - killing verb
@@ -6010,7 +5527,8 @@
     - manner verb [cxn]
     - result verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing such a <a>killing/injuring event</a>. <i>Example</i>: stabbing is a killing/injuring event, and <i>stab</i> is a killing/injuring verb. (Section 7.3.2)
 
 - Id: kinship relation [sem]
   Type: sem
@@ -6027,35 +5545,27 @@
 
 - Id: knowledge event [sem]
   Type: sem
-  InstanceOf: knowledge event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - knowledge event
+    - knowledge
   SubtypeOf:
     - propositional attitude event [sem]
   AssociatedTo:
     - epistemic stance [sem]
-  Definition: ""
-
-- Id: knowledge event [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - knowledge event/predicate
-    - knowledge
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>propositional attitude event</a> in which a <a>positive epistemic stance</a> toward the relevant <a>proposition</a> expressed is presupposed to be taken by the <u>speaker</u>; and the <a>predicate</a> expressing such an event. <i>Example</i>: in <i>Sally knows that Donald won the election</i>, Sally's belief with respect to the proposition that Donald won the election is reported by the speaker; and, in addition, a <a>positive epistemic stance</a> is taken by the speaker toward that proposition (i.e., the speaker believes that Donald indeed won the election). (Section 18.2.2)
+    a <a>propositional attitude event</a> in which a <a>positive epistemic stance</a> toward the relevant <a>proposition</a> expressed is presupposed to be taken by the <u>speaker</u>. <i>Example</i>: in <i>Sally knows that Donald won the election</i>, Sally's belief with respect to the proposition that Donald won the election is reported by the speaker; and, in addition, a <a>positive epistemic stance</a> is taken by the speaker toward that proposition (i.e., the speaker believes that Donald indeed won the election). (Section 18.2.2)
 
 - Id: knowledge predicate [cxn]
   Type: cxn
-  InstanceOf: knowledge event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - knowledge predicate
   SubtypeOf:
     - propositional attitude predicate [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>predicate</a> expressing a <a>knowledge event</a>. <i>Example</i>: in <i>Sally knows that Donald won the election</i>, Sally's belief with respect to the proposition that Donald won the election is reported by the speaker; and, in addition, a <a>positive epistemic stance</a> is taken by the speaker toward that proposition (i.e., the speaker believes that Donald indeed won the election). (Section 18.2.2)
 
 - Id: labile [str]
   Type: str
@@ -6176,7 +5686,7 @@
     - nonprototypical predication [cxn]
   AssociatedTo: []
   Definition: >-
-    a <a>clause</a> in which a locative relation is expressed, either <a>predicationally</a> or <a>presentationally</a>. These two types of location clauses are <a>locative predication</a> and <a>presentational locative</a>, respectively. (Section 10.4.1)
+    a <a>clause</a> in which a locative relation is expressed, either <a>predicationally</a> or <a>presentationally</a>. These two types of location clauses are <a predicational location>locative predication</a> and <a>presentational locative</a>, respectively. (Section 10.4.1)
 
 - Id: locational possessive strategy [str]
   Type: str
@@ -6330,35 +5840,27 @@
 
 - Id: manipulative event [sem]
   Type: sem
-  InstanceOf: manipulative event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - manipulative event
+    - manipulative
   SubtypeOf:
     - event [sem]
   AssociatedTo:
     - dependent time reference [sem]
-  Definition: ""
-
-- Id: manipulative event [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - manipulative event/predicate
-    - manipulative
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> where an <a>agent</a> acts to bring about the event expressed by the <a>complement</a>; and the <a>predicate</a> expressing such an event. <i>Example</i>: in <i>Bruce convinced Greg to take him to San Rafael, convinced</i> denotes a manipulative event. Manipulative events include causative and permissive events, and manipulative <a>complement clause constructions</a> overlap with <a>causative constructions</a>. The complement event of manipulative events has <a>dependent time reference</a>. (Section 18.2.2)
+    an <a>event</a> where an <a>agent</a> acts to bring about the event expressed by the <a>complement</a>. <i>Example</i>: in <i>Bruce convinced Greg to take him to San Rafael, convinced</i> denotes a manipulative event. Manipulative events include causative and permissive events. The complement event of manipulative events has <a>dependent time reference</a>. (Section 18.2.2)
 
 - Id: manipulative predicate [cxn]
   Type: cxn
-  InstanceOf: manipulative event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - manipulative predicate
   SubtypeOf:
     - predicate [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>predicate</a> expressing a <a>manipulative event</a>. <i>Example</i>: in <i>Bruce convinced Greg to take him to San Rafael, convinced</i> denotes a manipulative event. Manipulative <a>complement clause constructions</a> overlap with <a>causative constructions</a>. (Section 18.2.2)
 
 - Id: manner complex predicate [cxn]
   Type: cxn
@@ -6375,67 +5877,50 @@
 
 - Id: manner event [sem]
   Type: sem
-  InstanceOf: manner event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - manner event
   SubtypeOf:
     - event [sem]
   AssociatedTo:
     - manner complex predicate [cxn]
-  Definition: ""
-
-- Id: manner event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - manner event/verb
-    - manner
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
     an event that is described in terms of the manner by which the process progresses (or is brought about by an external cause). <i>Example</i>: in <i>She smeared jam on the toast</i>, the event is described in terms of the manner by which the jam is applied to the toast. (Section 7.3.2)
 
 - Id: manner of motion event [sem]
   Type: sem
-  InstanceOf: manner of motion event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - manner of motion event
+    - manner of motion
   SubtypeOf:
     - motion event [sem]
     - manner event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: manner of motion event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - manner of motion event/verb
-    - manner of motion
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an event that describes motion of a <a>figure</a> in terms of how the figure travels; and the <a>verb</a> expressing such an event. <i>Example</i>: in <i>Sam strode into the room, stride</i> is a manner of motion verb expressing a manner of motion event. (Sections 7.3.1, 14.2)
+    an event that describes motion of a <a>figure</a> in terms of how the figure travels. <i>Example</i>: in <i>Sam strode into the room, stride</i> is a manner of motion verb expressing a manner of motion event. (Sections 7.3.1, 14.2)
 
 - Id: manner of motion verb [cxn]
   Type: cxn
-  InstanceOf: manner of motion event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - manner of motion verb
   SubtypeOf:
     - manner verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing a <a>manner of motion event</a>. <i>Example</i>: in <i>Sam strode into the room, stride</i> is a manner of motion verb expressing a manner of motion event. (Sections 7.3.1, 14.2)
 
 - Id: manner verb [cxn]
   Type: cxn
-  InstanceOf: manner event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - manner verb
   SubtypeOf:
     - verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>verb</a> expressing a <a>manner event</a>. <i>Example</i>: in <i>She smeared jam on the toast</i>, the event is described in terms of the manner by which the jam is applied to the toast. (Section 7.3.2)
 
 - Id: material term [cxn]
   Type: cxn
@@ -6733,36 +6218,28 @@
 
 - Id: motion event [sem]
   Type: sem
-  InstanceOf: motion event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - motion event
+    - motion
   SubtypeOf:
     - monovalent event [sem]
   AssociatedTo:
     - middle voice [str]
     - ground [sem]
-  Definition: ""
-
-- Id: motion event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - motion event/verb
-    - motion
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>monovalent event</a> involving motion of a <a>participant</a> from one place to another (translational motion); and the <a>verb</a> expressing that event. <i>Examples</i>: <i>fly</i> and <i>go</i> express motion events. Motion events contrast with <a>bodily motion events</a>: motion events involve movement from one location to another, whereas bodily motion events involve internal motion of a body part. Motion events may express <a>path of motion</a> or <a>manner of motion</a>, or both. Motion events may be divided into <a>departure</a>, <a>passing</a>, and <a>arrival</a> phases of the path of motion. (Sections 7.2, 7.3.1, 14.4)
+    a <a>monovalent event</a> involving motion of a <a>participant</a> from one place to another (translational motion). <i>Examples</i>: <i>fly</i> and <i>go</i> express motion events. Motion events contrast with <a>bodily motion events</a>: motion events involve movement from one location to another, whereas bodily motion events involve internal motion of a body part. Motion events may express <a>path of motion</a> or <a>manner of motion</a>, or both. Motion events may be divided into <a>departure</a>, <a>passing</a>, and <a>arrival</a> phases of the path of motion. (Sections 7.2, 7.3.1, 14.4)
 
 - Id: motion verb [cxn]
   Type: cxn
-  InstanceOf: motion event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - motion verb
   SubtypeOf:
     - verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing a <a>motion event</a>. <i>Examples</i>: <i>fly</i> and <i>go</i> express motion events. (Sections 7.2, 7.3.1, 14.4)
 
 - Id: necessary participant sharing [sem]
   Type: sem
@@ -7047,41 +6524,33 @@
 
 - Id: nonspecific article [cxn]
   Type: cxn
-  InstanceOf: nonspecific referent [inf] / article [cxn] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - nonspecific article
   SubtypeOf:
     - article [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    an <a>article</a> that is used for a <a>nonspecific referent</a>. (Section 3.5)
 
 - Id: nonspecific pronoun [cxn]
   Type: cxn
-  InstanceOf: nonspecific referent [inf] / article [cxn] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - nonspecific pronoun
   SubtypeOf:
     - pronoun [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>pronoun</a> that expresses a <a>nonspecific referent</a>. (Section 3.5)
 
 - Id: nonspecific referent [inf]
   Type: inf
-  InstanceOf: nonspecific referent [inf] / article [cxn] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - nonspecific referent
   SubtypeOf:
     - information status [inf]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: nonspecific referent [inf] / article [cxn] / pronoun [cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - nonspecific referent/article/pronoun
-    - nonspecific
-  SubtypeOf: []
   AssociatedTo: []
   Definition: >-
     the information status of a referent whose identity cannot be known to the speaker and the hearer because the referent is only <a>type identifiable</a>. <i>Example</i>: in <i>A student came to my office</i>, the hearer does not know the identity of the student, and hence that referent is nonspecific. (Section 3.5)
@@ -7619,34 +7088,22 @@
 
 - Id: path (of motion) event [sem]
   Type: sem
-  InstanceOf: path (of motion) event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - path (of motion) event
     - path of motion event
+    - path of motion
     - path event
+    - path
   SubtypeOf:
     - motion event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: path (of motion) event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - path (of motion) event/verb
-    - path (of motion)
-    - path of motion event/verb
-    - path of motion
-    - path event/verb
-    - path
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an event that describes motion of a <a>figure</a> along a spatial path relative to a <a>ground</a>; and the <a>verb</a> expressing such an event. <i>Example</i>: in <i>The guests entered the reception hall, enter</i> is a path of motion verb expressing a path of motion event. (Sections 7.3.1, 14.2)
+    an event that describes motion of a <a>figure</a> along a spatial path relative to a <a>ground</a>. <i>Example</i>: in <i>The guests entered the reception hall, enter</i> is a path of motion verb expressing a path of motion event. (Sections 7.3.1, 14.2)
 
 - Id: path (of motion) verb [cxn]
   Type: cxn
-  InstanceOf: path (of motion) event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - path (of motion) verb
     - path of motion verb
@@ -7654,7 +7111,8 @@
   SubtypeOf:
     - verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing such a <a>path of motion event</a>. <i>Example</i>: in <i>The guests entered the reception hall, enter</i> is a path of motion verb expressing a path of motion event. (Sections 7.3.1, 14.2)
 
 - Id: patient [sem]
   Type: sem
@@ -7669,45 +7127,40 @@
 
 - Id: perception complement-taking predicate [cxn]
   Type: cxn
-  InstanceOf: perception event [sem] / verb [cxn] / complement-taking predicate [cxn]
+  InstanceOf: ""
   Alias:
     - perception complement-taking predicate
   SubtypeOf:
     - complement-taking predicate [cxn]
-  AssociatedTo: []
-  Definition: ""
+  AssociatedTo:
+    - perception event [sem]
+  Definition: >-
+    A perception complement-taking predicate is a <a>predicate</a> that expresses perceiving an event, which is expressed as the <a>complement</a> event of the predicate. <i>Example</i>: in <i>We watched the elk graze in the caldera</i>, watched denotes a perception event. The complement event has <a>dependent time reference</a>; the complement event must be occurring at the same time as the perceiving event (although modern media allowing watching a prior event via a recording). (Section 18.2.2)
 
 - Id: perception event [sem]
   Type: sem
-  InstanceOf: perception event [sem] / verb [cxn] / complement-taking predicate [cxn]
+  InstanceOf: ""
   Alias:
     - perception event
+    - perception
   SubtypeOf:
     - experiential event [sem]
   AssociatedTo:
     - dependent time reference [sem]
-  Definition: ""
-
-- Id: perception event [sem] / verb [cxn] / complement-taking predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - perception event/verb/complement-taking predicate
-    - perception
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>experiential event</a> involving one (or more) of the sensory modalities and directed toward a <a>stimulus</a>. The stimulus may be either an <a>object</a> or an <a>event</a>. A perception verb is a <a>verb</a> that expresses the event of perceiving an object. <i>Example</i>: <i>Tim heard the macaw</i> is an example of a perception event, and <i>hear</i> is the perception verb (Section 7.4). A perception complement-taking predicate is a <a>predicate</a> that expresses perceiving an event, which is expressed as the <a>complement</a> event of the predicate. <i>Example</i>: in <i>We watched the elk graze in the caldera</i>, watched denotes a perception event. The complement event has <a>dependent time reference</a>; the complement event must be occurring at the same time as the perceiving event (although modern media allowing watching a prior event via a recording). (Section 18.2.2)
+    an <a>experiential event</a> involving one (or more) of the sensory modalities and directed toward a <a>stimulus</a>. The stimulus may be either an <a>object</a> or an <a>event</a>. <i>Example</i>: <i>Tim heard the macaw</i> is an example of a perception event, and <i>hear</i> is the perception verb (Section 7.4).
 
 - Id: perception verb [cxn]
   Type: cxn
-  InstanceOf: perception event [sem] / verb [cxn] / complement-taking predicate [cxn]
+  InstanceOf: ""
   Alias:
     - perception verb
   SubtypeOf:
     - complement-taking predicate [cxn]
-  AssociatedTo: []
-  Definition: ""
+  AssociatedTo:
+    - perception event [sem]
+  Definition: >-
+    a perception verb is a <a>verb</a> that expresses the event of perceiving an object. <i>Example</i>: <i>Tim heard the macaw</i> is an example of a perception event, and <i>hear</i> is the perception verb (Section 7.4).
 
 - Id: perception verb strategy [str]
   Type: str
@@ -7863,67 +7316,54 @@
 
 - Id: polarity question [cxn]
   Type: cxn
-  InstanceOf: polarity question [inf/cxn]
-  Alias:
-    - polarity question
-  SubtypeOf:
-    - interrogative [cxn]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: polarity question [inf/cxn]
-  Type: inf/cxn
   InstanceOf: ""
   Alias:
     - polarity question
     - yes/no question
     - Y/N question
-  SubtypeOf: []
+  SubtypeOf:
+    - interrogative [cxn]
   AssociatedTo: []
   Definition: >-
-    an <a>interrogative</a> in which the unknown piece of the <a>propositional content</a> requested of the addressee is the <a>polarity</a> (<a>positive</a> or <a>negative</a>) of the proposition; and the <a>construction</a> expressing this function. <i>Example</i>: <i>Are you coming?</i> is an instance of the English polarity question construction, expecting a <q>yes</q> or <q>no</q> answer. (Section 12.3.1)
+    the <a>construction</a> expressing the <a>polarity question function</a>. <i>Example</i>: <i>Are you coming?</i> is an instance of the English polarity question construction, expecting a <q>yes</q> or <q>no</q> answer. (Section 12.3.1)
 
 - Id: polarity question [inf]
   Type: inf
-  InstanceOf: polarity question [inf/cxn]
+  InstanceOf: ""
   Alias:
     - polarity question
+    - polarity question function
   SubtypeOf:
     - interrogative [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    an <a>interrogative</a> in which the unknown piece of the <a>propositional content</a> requested of the addressee is the <a>polarity</a> (<a>positive</a> or <a>negative</a>) of the proposition. (Section 12.3.1)
 
 - Id: polarity response [cxn]
   Type: cxn
-  InstanceOf: polarity response [inf/cxn]
+  InstanceOf: ""
   Alias:
     - polarity response
+    - polarity answer
   SubtypeOf:
     - response [cxn]
   AssociatedTo:
     - polarity question [cxn]
-  Definition: ""
-
-- Id: polarity response [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - polarity response
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    the <u>answer</u> to a <a>polarity question</a>, and the <a>construction</a> that expresses that answer. <i>Example</i>: the polarity response to <i>Do you have any money?</i> in English is <i>Yes (I do)</i> or <i>No (I don't)</i>. (This is excluding other less cooperative responses such as <i>I don't know</i> or <i>It's none of your business</i>.) (Section 12.3.3)
+    the <a>construction</a> that expresses a <a>polarity answer</a>. <i>Example</i>: the polarity response to <i>Do you have any money?</i> in English is <i>Yes (I do)</i> or <i>No (I don't)</i>. (This is excluding other less cooperative responses such as <i>I don't know</i> or <i>It's none of your business</i>.) (Section 12.3.3)
 
 - Id: polarity response [inf]
   Type: inf
-  InstanceOf: polarity response [inf/cxn]
+  InstanceOf: ""
   Alias:
     - polarity response
+    - polarity answer
   SubtypeOf:
     - response [inf]
   AssociatedTo:
     - polarity question [inf]
-  Definition: ""
+  Definition: >-
+    the <u>answer</u> to a <a>polarity question</a>. <i>Example</i>: the polarity response to <i>Do you have any money?</i> in English is <i>Yes (I do)</i> or <i>No (I don't)</i>. (This is excluding other less cooperative responses such as <i>I don't know</i> or <i>It's none of your business</i>.) (Section 12.3.3)
 
 - Id: poset [inf]
   Type: inf
@@ -8137,7 +7577,7 @@
 
 - Id: pragmatically nonspecific (but semantically specific) (indefinite) article [cxn]
   Type: cxn
-  InstanceOf: pragmatically nonspecific (but semantically specific) (indefinite) referent [inf] / article [cxn]
+  InstanceOf: ""
   Alias:
     - pragmatically nonspecific (but semantically specific) (indefinite) article
     - pragmatically nonspecific (but semantically specific) indefinite article
@@ -8151,15 +7591,17 @@
   SubtypeOf:
     - article [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    an <a>article</a> that is used for a <a>pragmatically nonspecific (but semantically specific) indefinite referent</a>. (Section 3.4.1)
 
 - Id: pragmatically nonspecific (but semantically specific) (indefinite) referent [inf]
   Type: inf
-  InstanceOf: pragmatically nonspecific (but semantically specific) (indefinite) referent [inf] / article [cxn]
+  InstanceOf: ""
   Alias:
     - pragmatically nonspecific (but semantically specific) (indefinite) referent
     - pragmatically nonspecific (but semantically specific) indefinite referent
     - pragmatically nonspecific (but semantically specific) referent
+    - pragmatically nonspecific (but semantically specific)
     - pragmatically nonspecific but semantically specific (indefinite) referent
     - pragmatically nonspecific but semantically specific indefinite referent
     - pragmatically nonspecific but semantically specific referent
@@ -8169,39 +7611,12 @@
   SubtypeOf:
     - information status [inf]
   AssociatedTo: []
-  Definition: ""
-
-- Id: pragmatically nonspecific (but semantically specific) (indefinite) referent [inf] / article [cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - pragmatically nonspecific (but semantically specific) (indefinite) referent/article
-    - pragmatically nonspecific (but semantically specific) (indefinite)
-    - pragmatically nonspecific (but semantically specific) indefinite referent/article
-    - pragmatically nonspecific (but semantically specific) indefinite
-    - pragmatically nonspecific (but semantically specific) referent/article
-    - pragmatically nonspecific (but semantically specific)
-    - pragmatically nonspecific but semantically specific (indefinite) referent/article
-    - pragmatically nonspecific but semantically specific (indefinite)
-    - pragmatically nonspecific but semantically specific indefinite referent/article
-    - pragmatically nonspecific but semantically specific indefinite
-    - pragmatically nonspecific but semantically specific referent/article
-    - pragmatically nonspecific but semantically specific
-    - pragmatically nonspecific (indefinite) referent/article
-    - pragmatically nonspecific (indefinite)
-    - pragmatically nonspecific indefinite referent/article
-    - pragmatically nonspecific indefinite
-    - pragmatically nonspecific referent/article
-    - pragmatically nonspecific
-    - semantically specific
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
     a <a>referent</a> introduced into the discourse by the speaker that is not normally referred to again in subsequent discourse. The term <q>semantically specific</q> indicates that the referent is not in a nonreal context -- that is, it is not a nonspecific referent. We will use the shorter term <q>pragmatically nonspecific</q> and assume that such referents are also semantically specific. (Section 3.4.1)
 
 - Id: pragmatically specific (indefinite) article [cxn]
   Type: cxn
-  InstanceOf: pragmatically specific (indefinite) referent [inf] / article [cxn]
+  InstanceOf: ""
   Alias:
     - pragmatically specific (indefinite) article
     - pragmatically specific indefinite article
@@ -8209,31 +7624,19 @@
   SubtypeOf:
     - article [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    an <a>article</a> that is used for a <a>pragmatically specific referent</a>. (Section 3.4.1)
 
 - Id: pragmatically specific (indefinite) referent [inf]
   Type: inf
-  InstanceOf: pragmatically specific (indefinite) referent [inf] / article [cxn]
+  InstanceOf: ""
   Alias:
     - pragmatically specific (indefinite) referent
     - pragmatically specific indefinite referent
     - pragmatically specific referent
+    - pragmatically specific
   SubtypeOf:
     - information status [inf]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: pragmatically specific (indefinite) referent [inf] / article [cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - pragmatically specific (indefinite) referent/article
-    - pragmatically specific (indefinite)
-    - pragmatically specific indefinite referent/article
-    - pragmatically specific indefinite
-    - pragmatically specific referent/article
-    - pragmatically specific
-  SubtypeOf: []
   AssociatedTo: []
   Definition: >-
     a referent introduced into the discourse by the speaker that is normally referred to again in subsequent discourse. We will use the shorter term <q>pragmatically specific</q>. (Section 3.4.1)
@@ -8303,7 +7706,7 @@
 
 - Id: predicational [cxn]
   Type: cxn
-  InstanceOf: predicational [inf/cxn]
+  InstanceOf: ""
   Alias:
     - predicational
   SubtypeOf:
@@ -8311,60 +7714,42 @@
     - nonprototypical predication [cxn]
   AssociatedTo:
     - predicate nominal construction [cxn]
-  Definition: ""
-
-- Id: predicational [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - predicational
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    the subtype of <a>topic--comment</a> or <a>predication information packaging</a> in which membership in an <a>object</a> category is what is being predicated; and the <a>construction</a> that expresses that information packaging. <i>Example</i>: in <i>Bill is a teacher</i>, what is being predicated of Bill is that he is a member of the object category of teacher. In other words, <q>predicational</q> is synonymous with <a>object</a> <a>predication</a>. (Section 10.1.2)
+    the <a>construction</a> that expresses a <a>predicational</a> information packaging. <i>Example</i>: in <i>Bill is a teacher</i>, what is being predicated of Bill is that he is a member of the object category of teacher. (Section 10.1.2)
 
 - Id: predicational [inf]
   Type: inf
-  InstanceOf: predicational [inf/cxn]
+  InstanceOf: ""
   Alias:
     - predicational
   SubtypeOf:
     - topic--comment [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the subtype of <a>topic--comment</a> or <a>predication information packaging</a> in which membership in an <a>object</a> category is what is being predicated. <i>Example</i>: in <i>Bill is a teacher</i>, what is being predicated of Bill is that he is a member of the object category of teacher. In other words, <q>predicational</q> is synonymous with <a>object</a> <a>predication</a>. (Section 10.1.2)
 
 - Id: predicational location [cxn]
   Type: cxn
-  InstanceOf: predicational location [inf/cxn]
+  InstanceOf: ""
   Alias:
     - predicational location
   SubtypeOf:
     - location clause [cxn]
     - predicational [cxn]
   AssociatedTo: []
-  Definition: ""
-
-- Id: predicational location [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - predicational location
-    - predicational locative
-    - locative predication
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a spatial location situation with a <a>predicational</a> (<a>topic--comment</a>) <a>information packaging</a>, such that the <a>figure</a> in the spatial relation is the <a>topic</a> and its location (including the <a>ground</a>) is the <a>comment</a>; and the <a>construction</a> expressing that <a>function</a>. <i>Example</i>: <i>The pot is on the table</i> is an instance of the predicational locative construction. (Section 10.4.1)
+    the <a>construction</a> expressing a <a>predicational location</a> <a>function</a>. <i>Example</i>: <i>The pot is on the table</i> is an instance of the predicational locative construction. (Section 10.4.1)
 
 - Id: predicational location [inf]
   Type: inf
-  InstanceOf: predicational location [inf/cxn]
+  InstanceOf: ""
   Alias:
     - predicational location
   SubtypeOf:
     - predicational [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a spatial location situation with a <a>predicational</a> (<a>topic--comment</a>) <a>information packaging</a>, such that the <a>figure</a> in the spatial relation is the <a>topic</a> and its location (including the <a>ground</a>) is the <a>comment</a>. <i>Example</i>: <i>The pot is on the table</i> is an instance of the predicational locative construction. (Section 10.4.1)
 
 - Id: predicational locative strategy [str]
   Type: str
@@ -8462,7 +7847,7 @@
 
 - Id: presentational [cxn]
   Type: cxn
-  InstanceOf: presentational [inf/cxn]
+  InstanceOf: ""
   Alias:
     - presentational
   SubtypeOf:
@@ -8470,31 +7855,23 @@
     - nonpredicational clauses [cxn]
   AssociatedTo:
     - predicate nominal construction [cxn]
-  Definition: ""
-
-- Id: presentational [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - presentational
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a type of <a>entity-central</a> <a>thetic information packaging</a> that introduces a <a>referent</a> into the discourse, in order to make the identity of the referent known to the hearer; and the <a>construction</a> that expresses that information packaging. <i>Example</i>: <i>There's my bicycle</i> and <i>In the corner sat a mouse</i> are sentences that express the presentational information packaging function. Subtypes of the presentational construction are the <a>presentational location</a> and the <a>presentational possession constructions</a>. (Sections 10.1.2, 10.4)
+    the <a>construction</a> that expresses a <a>presentational</a> information packaging. <i>Example</i>: <i>There's my bicycle</i> and <i>In the corner sat a mouse</i> are sentences that express the presentational information packaging function. Subtypes of the presentational construction are the <a>presentational location</a> and the <a>presentational possession constructions</a>. (Sections 10.1.2, 10.4)
 
 - Id: presentational [inf]
   Type: inf
-  InstanceOf: presentational [inf/cxn]
+  InstanceOf: ""
   Alias:
     - presentational
   SubtypeOf:
     - entity-central [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a type of <a>entity-central</a> <a>thetic information packaging</a> that introduces a <a>referent</a> into the discourse, in order to make the identity of the referent known to the hearer. <i>Example</i>: <i>There's my bicycle</i> and <i>In the corner sat a mouse</i> are sentences that express the presentational information packaging function. (Sections 10.1.2, 10.4)
 
 - Id: presentational location [cxn]
   Type: cxn
-  InstanceOf: presentational location [inf/cxn]
+  InstanceOf: ""
   Alias:
     - presentational location
     - presentational locative
@@ -8502,27 +7879,19 @@
     - presentational [cxn]
     - location clause [cxn]
   AssociatedTo: []
-  Definition: ""
-
-- Id: presentational location [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - presentational location
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>presentational information packaging</a> of the spatial location relation in which the <a>figure</a> in the locative relation is introduced in the discourse, <a>anchored</a> by the <a>ground</a> <a>object</a>; and the <a>construction</a> expressing this <a>function</a>. <i>Example</i>: in <i>In the room was a request for breakfast</i>, the request for breakfast is being introduced into the discourse, anchored by its spatial relation to the room. (Sections 10.4.1, 10.4.3)
+    the <a>construction</a> expressing the <a>presentational location</a> <a>function</a>. <i>Example</i>: in <i>In the room was a request for breakfast</i>, the request for breakfast is being introduced into the discourse, anchored by its spatial relation to the room. (Sections 10.4.1, 10.4.3)
 
 - Id: presentational location [inf]
   Type: inf
-  InstanceOf: presentational location [inf/cxn]
+  InstanceOf: ""
   Alias:
     - presentational location
   SubtypeOf:
     - presentational [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>presentational information packaging</a> of the spatial location relation in which the <a>figure</a> in the locative relation is introduced in the discourse, <a>anchored</a> by the <a>ground</a> <a>object</a>. <i>Example</i>: in <i>In the room was a request for breakfast</i>, the request for breakfast is being introduced into the discourse, anchored by its spatial relation to the room. (Sections 10.4.1, 10.4.3)
 
 - Id: presentational possession [cxn]
   Type: cxn
@@ -8552,38 +7921,27 @@
 
 - Id: pretense event [sem]
   Type: sem
-  InstanceOf: pretense event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - pretence event
     - pretense event
   SubtypeOf:
     - propositional attitude event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: pretense event [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - pretense event/predicate
-    - pretense
-    - pretence event/predicate
-    - pretence
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>propositional attitude event</a> in which the speaker, or the <a>experiencer</a> of the pretense event, presents the <a>proposition</a> expressed by the <a>complement</a> as true in an alternative reality or <a>mental space</a>; and a <a>predicate</a> expressing such an event. <i>Example</i>: in <i>Ira pretended that the guests had already left</i>, the proposition that the guests had already left is presented as true in an alternative reality from the shared beliefs of the interlocutors (or, for that matter, Ira). There is a strong implicature that the proposition does not hold in reality (that is, the shared beliefs of the interlocutors). (Section 18.2.2)
+    a <a>propositional attitude event</a> in which the speaker, or the <a>experiencer</a> of the pretense event, presents the <a>proposition</a> expressed by the <a>complement</a> as true in an alternative reality or <a>mental space</a>. <i>Example</i>: in <i>Ira pretended that the guests had already left</i>, the proposition that the guests had already left is presented as true in an alternative reality from the shared beliefs of the interlocutors (or, for that matter, Ira). There is a strong implicature that the proposition does not hold in reality (that is, the shared beliefs of the interlocutors). (Section 18.2.2)
 
 - Id: pretense predicate [cxn]
   Type: cxn
-  InstanceOf: pretense event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - pretense predicate
     - pretence predicate
   SubtypeOf:
     - propositional attitude predicate [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>predicate</a> expressing a <a>pretense event</a>. <i>Example</i>: in <i>Ira pretended that the guests had already left</i>, the proposition that the guests had already left is presented as true in an alternative reality from the shared beliefs of the interlocutors (or, for that matter, Ira). There is a strong implicature that the proposition does not hold in reality (that is, the shared beliefs of the interlocutors). (Section 18.2.2)
 
 - Id: primary object category [str]
   Type: str
@@ -8601,34 +7959,26 @@
 
 - Id: prohibitive [cxn]
   Type: cxn
-  InstanceOf: prohibitive [inf/cxn]
+  InstanceOf: ""
   Alias:
     - prohibitive
   SubtypeOf:
     - imperative--hortative [cxn]
     - negation construction [cxn]
   AssociatedTo: []
-  Definition: ""
-
-- Id: prohibitive [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - prohibitive
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>negative</a> <a>imperative--hortative</a> <a>speech act</a>, and the <a>construction</a> that expresses that speech act. <i>Example</i>: English <i>Don't be a fool!</i> is an instance of a prohibitive; the construction uses a special prohibitive morpheme <i>Don't</i> to express prohibitive function. (Section 12.4.1)
+    the <a>construction</a> that expresses a <a>prohibitive</a> speech act. <i>Example</i>: English <i>Don't be a fool!</i> is an instance of a prohibitive; the construction uses a special prohibitive morpheme <i>Don't</i> to express prohibitive function. (Section 12.4.1)
 
 - Id: prohibitive [inf]
   Type: inf
-  InstanceOf: prohibitive [inf/cxn]
+  InstanceOf: ""
   Alias:
     - prohibitive
   SubtypeOf:
     - imperative--hortative [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>negative</a> <a>imperative--hortative</a> <a>speech act</a>. <i>Example</i>: English <i>Don't be a fool!</i> is an instance of a prohibitive. (Section 12.4.1)
 
 - Id: pronominal argument complex predicate [cxn]
   Type: cxn
@@ -8745,35 +8095,27 @@
 
 - Id: propositional attitude event [sem]
   Type: sem
-  InstanceOf: propositional attitude event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - propositional attitude event
+    - propositional attitude
   SubtypeOf:
     - event [sem]
   AssociatedTo:
     - independent time reference [sem]
-  Definition: ""
-
-- Id: propositional attitude event [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - propositional attitude event/predicate
-    - propositional attitude
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> of thinking, believing, and so on that expresses an attitude of the <a>experiencer</a> toward the truth of the <a>proposition</a> expressed by the <a>complement</a>; and the <a>predicate</a> expressing such an event. <i>Example</i>: in <i>Aram thought that the pianist was very good</i>, the <a>complement-taking predicate</a> <i>thought</i> denotes a propositional attitude event. Special cases of propositional attitude events are <a>knowledge events</a> and <a>pretense events</a>. (Section 18.2.2)
+    an <a>event</a> of thinking, believing, and so on that expresses an attitude of the <a>experiencer</a> toward the truth of the <a>proposition</a> expressed by the <a>complement</a>. <i>Example</i>: in <i>Aram thought that the pianist was very good</i>, the <a>complement-taking predicate</a> <i>thought</i> denotes a propositional attitude event. Special cases of propositional attitude events are <a>knowledge events</a> and <a>pretense events</a>. (Section 18.2.2)
 
 - Id: propositional attitude predicate [cxn]
   Type: cxn
-  InstanceOf: propositional attitude event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - propositional attitude predicate
   SubtypeOf:
     - complement-taking predicate [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>predicate</a> expressing such a <a>propositional attitude event</a>. <i>Example</i>: in <i>Aram thought that the pianist was very good</i>, the <a>complement-taking predicate</a> <i>thought</i> denotes a propositional attitude event. (Section 18.2.2)
 
 - Id: propositional content [sem]
   Type: sem
@@ -8803,36 +8145,29 @@
 
 - Id: protasis [cxn]
   Type: cxn
-  InstanceOf: protasis [sem/cxn]
-  Alias:
-    - protasis
-  SubtypeOf:
-    - clause [cxn]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: protasis [sem/cxn]
-  Type: sem/cxn
   InstanceOf: ""
   Alias:
     - protasis
     - antecedent
-  SubtypeOf: []
+  SubtypeOf:
+    - clause [cxn]
   AssociatedTo: []
   Definition: >-
-    the <a>clause</a> expressing the causally antecedent <a>proposition</a> in a <a>causal</a>, <a>conditional</a>, <a>concessive</a>, <a>concessive conditional</a>, or <a>comparative conditional construction</a>; or the proposition or <a>event</a> denoted by the clause. <i>Example</i>: in <i>If you press this button, the door will open</i>, <i>If you press this button</i> is the protasis; <i>the door will open</i> is the <a>apodosis</a>. Since the conditional relations are defined in terms of both logical implication and causal relation, the semantic use of <q>protasis</q> can be distinguished as <q>protasis proposition</q> or <q>protasis event</q>. (Section 17.3.1)
+    the <a>clause</a> expressing the causally antecedent <a>proposition</a> in a <a>causal</a>, <a>conditional</a>, <a>concessive</a>, <a>concessive conditional</a>, or <a>comparative conditional construction</a>. <i>Example</i>: in <i>If you press this button, the door will open</i>, <i>If you press this button</i> is the protasis; <i>the door will open</i> is the <a>apodosis</a>. (Section 17.3.1)
 
 - Id: protasis [sem]
   Type: sem
-  InstanceOf: protasis [sem/cxn]
+  InstanceOf: ""
   Alias:
     - protasis
   SubtypeOf:
     - proposition [sem]
+    - event [sem]
   AssociatedTo:
     - epistemic stance [sem]
     - conditional relation [sem]
-  Definition: ""
+  Definition: >-
+    the proposition or <a>event</a> denoted by a <a>protasis</a> clause. <i>Example</i>: in <i>If you press this button, the door will open</i>, <i>If you press this button</i> is the protasis; <i>the door will open</i> is the <a>apodosis</a>. Since the conditional relations are defined in terms of both logical implication and causal relation, the semantic use of <q>protasis</q> can be distinguished as <q>protasis proposition</q> or <q>protasis event</q>. (Section 17.3.1)
 
 - Id: prototypical construction [cxn]
   Type: cxn
@@ -8908,34 +8243,25 @@
 
 - Id: pursuit event [sem]
   Type: sem
-  InstanceOf: pursuit event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - pursuit event
   SubtypeOf:
     - event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: pursuit event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - pursuit event/verb
-    - pursuit
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    <a>events</a> in which one <a>participant's</a> motion or location is directed toward another participant; and the <a>verb</a> expressing such an event. <i>Examples</i>: pursuit events include following, chasing, searching for something, and waiting for someone/something; and <i>follow</i>, <i>chase</i>, <i>search (for)</i>, and <i>wait (for)</i> are pursuit verbs. (Section 7.3.3)
+    <a>events</a> in which one <a>participant's</a> motion or location is directed toward another participant. <i>Examples</i>: pursuit events include following, chasing, searching for something, and waiting for someone/something; and <i>follow</i>, <i>chase</i>, <i>search (for)</i>, and <i>wait (for)</i> are pursuit verbs. (Section 7.3.3)
 
 - Id: pursuit verb [cxn]
   Type: cxn
-  InstanceOf: pursuit event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - pursuit verb
   SubtypeOf:
     - verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing a <a>pursuit event</a>. <i>Examples</i>: pursuit events include following, chasing, searching for something, and waiting for someone/something; and <i>follow</i>, <i>chase</i>, <i>search (for)</i>, and <i>wait (for)</i> are pursuit verbs. (Section 7.3.3)
 
 - Id: quantifier [cxn]
   Type: cxn
@@ -8951,32 +8277,23 @@
 
 - Id: question pronoun [cxn]
   Type: cxn
-  InstanceOf: question referent [inf] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - question pronoun
   SubtypeOf:
     - pronoun [cxn]
   AssociatedTo:
     - information question [cxn]
-  Definition: ""
+  Definition: >-
+    a <a>pronoun</a> that expresses a <a>question referent</a>. (Section 3.5)
 
 - Id: question referent [inf]
   Type: inf
-  InstanceOf: question referent [inf] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - question referent
   SubtypeOf:
     - nonspecific referent [inf]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: question referent [inf] / pronoun [cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - question referent/pronoun
-    - question
-  SubtypeOf: []
   AssociatedTo: []
   Definition: >-
     an unspecified <a>referent</a> in the scope of <a interrogative>interrogation</a>, especially <a polarity>polar</a> <a>interrogatives</a>. <i>Example</i>: in <i>Can you hear <b>anything</b>?</i>, <i>anything</i> is a question pronoun expressing a referent that only <dq>exists</dq> in a hypothetical world, the possibility of whose existence is being entertained by the questioner. (Section 3.5)
@@ -9022,35 +8339,26 @@
 
 - Id: reciprocal construction [cxn]
   Type: cxn
-  InstanceOf: reciprocal event [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - reciprocal construction
   SubtypeOf:
     - reference tracking [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>construction</a> expressing such a <a>reciprocal event</a>. <i>Example</i>: in <i>Mary and Sue praised each other</i>, Mary praises Sue and Sue praises Mary. (Section 7.2)
 
 - Id: reciprocal event [sem]
   Type: sem
-  InstanceOf: reciprocal event [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - reciprocal event
   SubtypeOf:
     - event [sem]
   AssociatedTo:
     - monoclausal transitive reciprocal strategy [str]
-  Definition: ""
-
-- Id: reciprocal event [sem] / construction [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - reciprocal event/construction
-    - reciprocal
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> type in which one <a>participant</a> acts upon another participant, and the second participant acts on the first in the same way; and the <a>construction</a> expressing such an event. That is, each participant is both the <a>initiator</a> and <a>endpoint</a> of <a>transmission of force</a> for the same type of action. <i>Example</i>: in <i>Mary and Sue praised each other</i>, Mary praises Sue and Sue praises Mary. (Section 7.2)
+    an <a>event</a> type in which one <a>participant</a> acts upon another participant, and the second participant acts on the first in the same way. That is, each participant is both the <a>initiator</a> and <a>endpoint</a> of <a>transmission of force</a> for the same type of action. <i>Example</i>: in <i>Mary and Sue praised each other</i>, Mary praises Sue and Sue praises Mary. (Section 7.2)
 
 - Id: recruitment strategy [str]
   Type: str
@@ -9134,34 +8442,26 @@
 
 - Id: reflexive construction [cxn]
   Type: cxn
-  InstanceOf: reflexive event [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - reflexive construction
   SubtypeOf:
     - reference tracking [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>construction</a> expressing a <a>reflexive event</a>. <i>Examples</i>: reflexive events may be direct, when there is no other participant, as in <i>I saw myself</i>; or indirect, when there is another participant in an intermediate position in the <a>causal chain</a>, as in <i>Sally baked a cake for herself</i>, whose causal structure is Sally --> cake --> Sally. (Section 7.2)
 
 - Id: reflexive event [sem]
   Type: sem
-  InstanceOf: reflexive event [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - reflexive event
+    - reflexive
   SubtypeOf:
     - event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: reflexive event [sem] / construction [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - reflexive event/construction
-    - reflexive
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> type in which a <a>participant</a> acts upon themself -- that is, the participant is both the <a>initiator</a> and <a>endpoint</a> of <a>transmission of force</a>; and the <a>construction</a> expressing such an event. <i>Examples</i>: reflexive events may be direct, when there is no other participant, as in <i>I saw myself</i>; or indirect, when there is another participant in an intermediate position in the <a>causal chain</a>, as in <i>Sally baked a cake for herself</i>, whose causal structure is Sally --> cake --> Sally. (Section 7.2)
+    an <a>event</a> type in which a <a>participant</a> acts upon themself -- that is, the participant is both the <a>initiator</a> and <a>endpoint</a> of <a>transmission of force</a>. <i>Examples</i>: reflexive events may be direct, when there is no other participant, as in <i>I saw myself</i>; or indirect, when there is another participant in an intermediate position in the <a>causal chain</a>, as in <i>Sally baked a cake for herself</i>, whose causal structure is Sally --> cake --> Sally. (Section 7.2)
 
 - Id: rejecting [inf]
   Type: inf
@@ -9293,7 +8593,7 @@
   AssociatedTo:
     - equative construction [cxn]
   Definition: >-
-    a <a>derived-case strategy</a> for <a>equative constructions</a> which consists of a <a>relative clause</a>-like <a>construction</a> where the <a>matrix clause</a> expresses that the <a>gradable predicative scale</a> applies to the <a>comparee</a>, and a relative clause expresses that the same scale applies to the <a>standard</a>. The relative clause is reduced to a <a>relativizer</a> and an <a>argument phrase</a> expressing the standard; the <a>zero strategy</a> is used for <a>predicate identity</a>. <i>Example</i>: Lithuanian <i>Šiandien taip šalta kaip vakar</i> <q>Today it is as cold as yesterday</q> is an instance of the relative-based equative strategy: <i>Šiandien taip šalta</i> <q>today [is] so cold</q> is the matrix clause, with the degree marker <i>taip</i> <q>so</q>, and <i>kaip vakar</i> <q>how yesterday</q> is the relative-based clause, with the pronoun <i>kaip</i> <q>how</q>, the standard, <q>yesterday</q>, and a zero predicate. Typically the relative-based equative recruits a correlative relative clause, with a <a free relative clause>free</a> (<a indefinite pronoun/article>indefinite head</a>) <a relative clause>relative</a> or interrogative-based <a>relative pronoun</a>. (Section 17.2.4)
+    a <a>derived-case strategy</a> for <a>equative constructions</a> which consists of a <a>relative clause</a>-like <a>construction</a> where the <a>matrix clause</a> expresses that the <a>gradable predicative scale</a> applies to the <a>comparee</a>, and a relative clause expresses that the same scale applies to the <a>standard</a>. The relative clause is reduced to a <a>relativizer</a> and an <a>argument phrase</a> expressing the standard; the <a>zero strategy</a> is used for <a>predicate identity</a>. <i>Example</i>: Lithuanian <i>Šiandien taip šalta kaip vakar</i> <q>Today it is as cold as yesterday</q> is an instance of the relative-based equative strategy: <i>Šiandien taip šalta</i> <q>today [is] so cold</q> is the matrix clause, with the degree marker <i>taip</i> <q>so</q>, and <i>kaip vakar</i> <q>how yesterday</q> is the relative-based clause, with the pronoun <i>kaip</i> <q>how</q>, the standard, <q>yesterday</q>, and a zero predicate. Typically the relative-based equative recruits a correlative relative clause, with a <a free relative clause>free</a> (<a indefinite pronoun>indefinite head</a>) <a relative clause>relative</a> or interrogative-based <a>relative pronoun</a>. (Section 17.2.4)
 
 - Id: relativizer [str]
   Type: str
@@ -9309,35 +8609,27 @@
 
 - Id: removal event [sem]
   Type: sem
-  InstanceOf: removal event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - removal event
+    - removal
   SubtypeOf:
     - event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: removal event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - removal event/verb
-    - removal
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> describing removal of an <a>object</a> from another object; and the <a>verb</a> expressing such an event. <i>Example</i>: scrubbing is a removal event, and <i>scrub</i> is a removal verb. (Section 7.3.2)
+    an <a>event</a> describing removal of an <a>object</a> from another object. <i>Example</i>: scrubbing is a removal event. (Section 7.3.2)
 
 - Id: removal verb [cxn]
   Type: cxn
-  InstanceOf: removal event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - removal verb
   SubtypeOf:
     - manner verb [cxn]
     - result verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing a <a>removal event</a>. <i>Example</i>: scrubbing is a removal event, and <i>scrub</i> is a removal verb. (Section 7.3.2)
 
 - Id: repeater [str]
   Type: str
@@ -9363,35 +8655,28 @@
 
 - Id: response [cxn]
   Type: cxn
-  InstanceOf: response [inf/cxn]
+  InstanceOf: ""
   Alias:
     - response
   SubtypeOf:
     - speech acts [cxn]
   AssociatedTo:
     - interrogative [cxn]
-  Definition: ""
-
-- Id: response [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - response
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    the answer to an <a>interrogative</a> (question) <a>speech act</a>; and the <a>construction</a> expressing the answer. Like interrogatives, responses are divided into <a>polarity responses</a> and <a>information (question) responses</a>.
+    the <a>construction</a> expressing a <a>answer</a> <a>function</a>. Like interrogatives, responses are divided into <a>polarity responses</a> and <a>information (question) responses</a>.
 
 - Id: response [inf]
   Type: inf
-  InstanceOf: response [inf/cxn]
+  InstanceOf: ""
   Alias:
     - response
+    - answer
   SubtypeOf:
     - speech acts [inf]
   AssociatedTo:
     - interrogative [inf]
-  Definition: ""
+  Definition: >-
+    the answer to an <a>interrogative</a> (question) <a>speech act</a>. Like interrogatives, responses are divided into <a>polarity responses</a> and <a>information (question) responses</a>.
 
 - Id: restricting [inf]
   Type: inf
@@ -9432,34 +8717,26 @@
 
 - Id: result event [sem]
   Type: sem
-  InstanceOf: result event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - result event
+    - result
   SubtypeOf:
     - event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: result event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - result event/verb
-    - result
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> that is described in terms of reaching a result state, often by means of a scalar change (<a>directed change</a>), and the <a>verb</a> expressing such an event. <i>Example</i>: in <i>Peter broke the window</i>, the event is described in terms of the result state that is reached (a broken window). (Section 7.3.2)
+    an <a>event</a> that is described in terms of reaching a result state, often by means of a scalar change (<a>directed change</a>). <i>Example</i>: in <i>Peter broke the window</i>, the event is described in terms of the result state that is reached (a broken window). (Section 7.3.2)
 
 - Id: result verb [cxn]
   Type: cxn
-  InstanceOf: result event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - result verb
   SubtypeOf:
     - verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing a <a>result event</a>. <i>Example</i>: in <i>Peter broke the window</i>, the event is described in terms of the result state that is reached (a broken window). (Section 7.3.2)
 
 - Id: resultative (complex predicate) [cxn]
   Type: cxn
@@ -9715,35 +8992,26 @@
 
 - Id: sensation event [sem]
   Type: sem
-  InstanceOf: sensation event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - sensation event
     - bodily sensation event
   SubtypeOf:
     - experiential event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: sensation event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - sensation event/verb
-    - sensation
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>experiential event</a> involving an internal bodily or physiological sensation; and a <a>verb</a> that expresses such an event. <i>Example</i>: <i>My head aches</i> is an example of a sensation event, and <i>ache</i> is the sensation verb. (Section 7.4)
+    an <a>experiential event</a> involving an internal bodily or physiological sensation. <i>Example</i>: <i>My head aches</i> is an example of a sensation event. (Section 7.4)
 
 - Id: sensation verb [cxn]
   Type: cxn
-  InstanceOf: sensation event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - sensation verb
   SubtypeOf:
     - experiential verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>verb</a> that expresses a <a>sensation event</a>. <i>Example</i>: <i>My head aches</i> is an example of a sensation event, and <i>ache</i> is the sensation verb. (Section 7.4)
 
 - Id: separative comparative [str]
   Type: str
@@ -9963,69 +9231,51 @@
 
 - Id: specific known pronoun [cxn]
   Type: cxn
-  InstanceOf: specific known referent [inf] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - specific known pronoun
   SubtypeOf:
     - pronoun [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>pronoun</a> that expresses a <a>specific known referent</a>. <i>Example</i>: if <i>Masha met with someone near the university</i> is used in a context where the speaker knows the identity of the person Masha met, then <i>someone</i> is a specific known pronoun expressing a specific known referent. (Section 3.5)
 
 - Id: specific known referent [inf]
   Type: inf
-  InstanceOf: specific known referent [inf] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - specific known referent
   SubtypeOf:
     - identifiability, identity [inf]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: specific known referent [inf] / pronoun [cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - specific known referent/pronoun
-    - specific known
-  SubtypeOf: []
   AssociatedTo: []
   Definition: >-
     a real-world <a>referent</a> whose identity is known to the speaker but not the hearer. <i>Example</i>: if <i>Masha met with someone near the university</i> is used in a context where the speaker knows the identity of the person Masha met, then <i>someone</i> is a specific known pronoun expressing a specific known referent. (Section 3.5)
 
 - Id: specific unknown pronoun [cxn]
   Type: cxn
-  InstanceOf: specific unknown referent [inf] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - specific unknown pronoun
   SubtypeOf:
     - pronoun [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    a <a>pronoun</a> that expresses a <a>specific unknown referent</a>. <i>Example</i>: if <i>Masha met with somebody near the university</i> is used in a context where the speaker does not know the identity of the person Masha met, then <i>somebody</i> is a specific unknown pronoun expressing a specific unknown referent. (Section 3.5)
 
 - Id: specific unknown referent [inf]
   Type: inf
-  InstanceOf: specific unknown referent [inf] / pronoun [cxn]
+  InstanceOf: ""
   Alias:
     - specific unknown referent
   SubtypeOf:
     - identifiability, identity [inf]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: specific unknown referent [inf] / pronoun [cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - specific unknown referent/pronoun
-    - specific unknown
-  SubtypeOf: []
   AssociatedTo: []
   Definition: >-
     a real-world <a>referent</a> whose identity is known neither to the speaker nor to the hearer. <i>Example</i>: if <i>Masha met with somebody near the university</i> is used in a context where the speaker does not know the identity of the person Masha met, then <i>somebody</i> is a specific unknown pronoun expressing a specific unknown referent. (Section 3.5)
 
 - Id: speech act causal construction [cxn]
   Type: cxn
-  InstanceOf: speech act causal relation [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - speech act causal construction
   SubtypeOf:
@@ -10034,25 +9284,16 @@
     - concessive construction [cxn]
     - concessive conditional construction [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the construction expressing a <a>speech act causal relation</a>. <i>Example</i>: in <i>Since you asked, ten isn't a prime number</i>, there is a speech act causal relation between the request of the speaker whether ten is a prime number, and the performance of the speech act asserting that ten isn't a prime number. (Section 17.3.1)
 
 - Id: speech act causal relation [sem]
   Type: sem
-  InstanceOf: speech act causal relation [sem] / construction [cxn]
+  InstanceOf: ""
   Alias:
     - speech act causal relation
   SubtypeOf:
     - causal [sem]
-  AssociatedTo: []
-  Definition: ""
-
-- Id: speech act causal relation [sem] / construction [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - speech act causal relation/construction
-    - speech act causal
-  SubtypeOf: []
   AssociatedTo: []
   Definition: >-
     the semantic relation in a <a>conditional</a>, <a>causal</a>, <a>concessive</a>, or <a>conditional concessive construction</a> that expresses a relation between a condition on performing a <a>speech act</a> and the performance of that speech act; and the construction expressing that relation. <i>Example</i>: in <i>Since you asked, ten isn't a prime number</i>, there is a speech act causal relation between the request of the speaker whether ten is a prime number, and the performance of the speech act asserting that ten isn't a prime number. A speech act causal relation contrasts with a <a>content causal relation</a> and an <a>epistemic causal relation</a>. (Section 17.3.1)
@@ -10069,33 +9310,25 @@
 
 - Id: speech acts [cxn]
   Type: cxn
-  InstanceOf: speech acts [inf/cxn]
+  InstanceOf: ""
   Alias:
     - speech acts
   SubtypeOf:
     - construction [def]
   AssociatedTo: []
-  Definition: ""
-
-- Id: speech acts [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - speech acts
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    speech acts package the <a>propositional content</a> of the utterance in such a way that the speaker wants or requires an explicit response from the addressee with respect to the propositional content; and the <a>constructions</a> used to express this function. The speech acts that are most likely to be expressed as distinct constructions are the <a>declarative</a>, the <a>interrogative</a>, the <a>imperative--hortative</a> and its negative the <a>prohibitive</a>, and the <a>exclamative</a>. (Section 12.1)
+    the <a>constructions</a> used to express <a>speech acts</a> functions. (Section 12.1)
 
 - Id: speech acts [inf]
   Type: inf
-  InstanceOf: speech acts [inf/cxn]
+  InstanceOf: ""
   Alias:
     - speech acts
   SubtypeOf:
     - information packaging [def]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    speech acts package the <a>propositional content</a> of the utterance in such a way that the speaker wants or requires an explicit response from the addressee with respect to the propositional content. The speech acts that are most likely to be expressed as distinct constructions are the <a>declarative</a>, the <a>interrogative</a>, the <a>imperative--hortative</a> and its negative the <a>prohibitive</a>, and the <a>exclamative</a>. (Section 12.1)
 
 - Id: split argument structure strategy [str]
   Type: str
@@ -10125,35 +9358,26 @@
 
 - Id: spontaneous event [sem]
   Type: sem
-  InstanceOf: spontaneous event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - spontaneous event
   SubtypeOf:
     - monovalent event [sem]
   AssociatedTo:
     - middle voice [str]
-  Definition: ""
-
-- Id: spontaneous event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - spontaneous event/verb
-    - spontaneous
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>monovalent event</a> involving a <a>participant</a> that undergoes a change without an external cause; and the <a>verb</a> expressing that event. <i>Examples</i>: dying and melting are spontaneous events, and <i>die</i> and <i>melt</i> are spontaneous event verbs. (Sections 6.3.4, 7.2)
+    a <a>monovalent event</a> involving a <a>participant</a> that undergoes a change without an external cause. <i>Examples</i>: dying and melting are spontaneous events. (Sections 6.3.4, 7.2)
 
 - Id: spontaneous verb [cxn]
   Type: cxn
-  InstanceOf: spontaneous event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - spontaneous verb
   SubtypeOf:
     - verb [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>verb</a> expressing a <a>spontaneous event</a>. <i>Examples</i>: dying and melting are spontaneous events, and <i>die</i> and <i>melt</i> are spontaneous event verbs. (Sections 6.3.4, 7.2)
 
 - Id: stable [sem]
   Type: sem
@@ -10557,34 +9781,25 @@
 
 - Id: temporary predicate [cxn]
   Type: cxn
-  InstanceOf: temporary state [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - temporary predicate
   SubtypeOf:
     - predicate [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>predicates</a> that express the class of <a>temporary state</a> events. <i>Example</i>: being sick is a temporary state, and <i>(be) sick</i> is a temporary state predicate. (Section 6.3.3)
 
 - Id: temporary state [sem]
   Type: sem
-  InstanceOf: temporary state [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - temporary state
   SubtypeOf:
     - state [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: temporary state [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - temporary state/predicate
-    - temporary
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    the <a>event</a> class of <a>stative</a> properties that are temporary and thus have come about through some process; and the <a>predicates</a> that express events in this class. <i>Example</i>: being sick is a temporary state, and <i>(be) sick</i> is a temporary state predicate. (Section 6.3.3)
+    the <a>event</a> class of <a>stative</a> properties that are temporary and thus have come about through some process. <i>Example</i>: being sick is a temporary state. (Section 6.3.3)
 
 - Id: tense [sem]
   Type: sem
@@ -10635,34 +9850,26 @@
 
 - Id: thetic [cxn]
   Type: cxn
-  InstanceOf: thetic [inf/cxn]
+  InstanceOf: ""
   Alias:
     - thetic
   SubtypeOf:
     - clause [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>construction</a> that expresses a <a>thetic</a> information packaging. <i>Example</i>: <i>TRUMP was elected!</i> (with accent on <i>Trump</i>), uttered on November 9, 2016, is thetic, in that this information is expressed as all new -- in this case because it was unexpected at the time. (Sections 10.1.2, 11.1, <b>11.3.1</b>)
 
-- Id: thetic [inf/cxn]
-  Type: inf/cxn
+- Id: thetic [inf]
+  Type: inf
   InstanceOf: ""
   Alias:
     - thetic
     - all new
-  SubtypeOf: []
-  AssociatedTo: []
-  Definition: >-
-    <a>information packaging</a> that does not split the information into a <a>topic</a> and a <a>comment</a>, as is done in the <a>topic--comment</a> information packaging; and the <a>construction</a> that expresses that information packaging. Instead, the information is presented as a single whole, hence the alternative name <q>all new</q>. <i>Example</i>: <i>TRUMP was elected!</i> (with accent on <i>Trump</i>), uttered on November 9, 2016, is thetic, in that this information is expressed as all new -- in this case because it was unexpected at the time. (Sections 10.1.2, 11.1, <b>11.3.1</b>)
-
-- Id: thetic [inf]
-  Type: inf
-  InstanceOf: thetic [inf/cxn]
-  Alias:
-    - thetic
   SubtypeOf:
     - predication [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    <a>information packaging</a> that does not split the information into a <a>topic</a> and a <a>comment</a>, as is done in the <a>topic--comment</a> information packaging. Instead, the information is presented as a single whole, hence the alternative name <q>all new</q>. <i>Example</i>: <i>TRUMP was elected!</i> (with accent on <i>Trump</i>), uttered on November 9, 2016, is thetic, in that this information is expressed as all new -- in this case because it was unexpected at the time. (Sections 10.1.2, 11.1, <b>11.3.1</b>)
 
 - Id: third person pronoun [cxn]
   Type: cxn
@@ -10750,34 +9957,25 @@
 
 - Id: topic--comment [cxn]
   Type: cxn
-  InstanceOf: topic--comment [inf/cxn]
+  InstanceOf: ""
   Alias:
     - topic--comment
   SubtypeOf:
     - clause [cxn]
   AssociatedTo: []
-  Definition: ""
-
-- Id: topic--comment [inf/cxn]
-  Type: inf/cxn
-  InstanceOf: ""
-  Alias:
-    - topic--comment
-    - categorical
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    the <a>information packaging</a> in which one concept (the <a>comment</a>) is <a predicated>predicated about</a> another concept which is <a reference>referred</a> to (the <a>topic</a>); and the <a>construction</a> that expresses that information packaging. <i>Example</i>: <i>The bus stopped</i> is an instance of a topic--comment construction in which <i>stopped</i> is the comment and <i>The bus</i> is the topic. Topic--comment information packaging is basically synonymous with <a>predication</a>; the term <q>topic--comment</q> highlights the fact that a predication is a predication about a <a>referent</a>. (Sections 2.2.2, 10.1.2, 11.1, <b>11.2.1</b>)
+    the <a>construction</a> that expresses a <a>topic--comment</a> information packaging. <i>Example</i>: <i>The bus stopped</i> is an instance of a topic--comment construction in which <i>stopped</i> is the comment and <i>The bus</i> is the topic. (Sections 2.2.2, 10.1.2, 11.1, <b>11.2.1</b>)
 
 - Id: topic--comment [inf]
   Type: inf
-  InstanceOf: topic--comment [inf/cxn]
+  InstanceOf: ""
   Alias:
     - topic--comment
   SubtypeOf:
     - predication [inf]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>information packaging</a> in which one concept (the <a>comment</a>) is <a predicated>predicated about</a> another concept which is <a reference>referred</a> to (the <a>topic</a>). <i>Example</i>: <i>The bus stopped</i> is an instance of a topic--comment construction in which <i>stopped</i> is the comment and <i>The bus</i> is the topic. Topic--comment information packaging is basically synonymous with <a>predication</a>; the term <q>topic--comment</q> highlights the fact that a predication is a predication about a <a>referent</a>. (Sections 2.2.2, 10.1.2, 11.1, <b>11.2.1</b>)
 
 - Id: topic-locational hybrid possessive strategy [str]
   Type: str
@@ -10793,35 +9991,26 @@
 
 - Id: transfer event [sem]
   Type: sem
-  InstanceOf: transfer event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - transfer event
   SubtypeOf:
     - trivalent event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: transfer event [sem] / verb [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - transfer event/verb
-    - transfer
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    a <a>trivalent event</a> involving physical transfer, usually also extended to <dq>mental transfer</dq>, that is used in defining the <a>ditransitive construction</a>; and a <a>verb</a> that expresses such an event. <i>Examples</i>: giving and sending are physical transfer events (and <i>give</i> and <i>send</i> are transfer verbs), and showing and telling are <dq>mental transfer</dq> events (and <i>show</i> and <i>tell</i> are <dq>mental transfer</dq> verbs). (Section 7.5.1)
+    a <a>trivalent event</a> involving physical transfer, usually also extended to <dq>mental transfer</dq>, that is used in defining the <a>ditransitive construction</a>. <i>Examples</i>: giving and sending are physical transfer events (and <i>give</i> and <i>send</i> are transfer verbs), and showing and telling are <dq>mental transfer</dq> events (and <i>show</i> and <i>tell</i> are <dq>mental transfer</dq> verbs). (Section 7.5.1)
 
 - Id: transfer verb [cxn]
   Type: cxn
-  InstanceOf: transfer event [sem] / verb [cxn]
+  InstanceOf: ""
   Alias:
     - transfer verb
   SubtypeOf:
     - verb [cxn]
   AssociatedTo:
     - ditransitive construction [cxn]
-  Definition: ""
+  Definition: >-
+    a <a>verb</a> that expresses a <a>transfer event</a>. <i>Examples</i>: giving and sending are physical transfer events (and <i>give</i> and <i>send</i> are transfer verbs), and showing and telling are <dq>mental transfer</dq> events (and <i>show</i> and <i>tell</i> are <dq>mental transfer</dq> verbs). (Section 7.5.1)
 
 - Id: transitive construction [cxn]
   Type: cxn
@@ -11000,34 +10189,25 @@
 
 - Id: uncontrolled activity [sem]
   Type: sem
-  InstanceOf: uncontrolled activity [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - uncontrolled activity
   SubtypeOf:
     - event [sem]
   AssociatedTo: []
-  Definition: ""
-
-- Id: uncontrolled activity [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - uncontrolled activity/predicate
-    - uncontrolled
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    the <a>event</a> class of activities not under the control of an <a>agent</a> (apart from uncontrolled <a>bodily actions</a> and <a>change of state</a>); and the <a>predicates</a> that express events in this class. <i>Example</i>: dying is an uncontrolled activity, and <i>die</i> is an uncontrolled activity predicate. (Section 6.3.3)
+    the <a>event</a> class of activities not under the control of an <a>agent</a> (apart from uncontrolled <a>bodily actions</a> and <a>change of state</a>). <i>Example</i>: dying is an uncontrolled activity. (Section 6.3.3)
 
 - Id: uncontrolled predicate [cxn]
   Type: cxn
-  InstanceOf: uncontrolled activity [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - uncontrolled predicate
   SubtypeOf:
     - predicate [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>predicates</a> that express the class of <a>uncontrolled activity</a> events. <i>Example</i>: dying is an uncontrolled activity, and <i>die</i> is an uncontrolled activity predicate. (Section 6.3.3)
 
 - Id: undirected change [sem]
   Type: sem
@@ -11078,35 +10258,27 @@
 
 - Id: utterance event [sem]
   Type: sem
-  InstanceOf: utterance event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - utterance event
+    - utterance
   SubtypeOf:
     - event [sem]
   AssociatedTo:
     - independent time reference [sem]
-  Definition: ""
-
-- Id: utterance event [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - utterance event/predicate
-    - utterance
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>event</a> of saying in which one <a>participant</a> is the <u>speaker</u> of the utterance and another participant is the utterance itself; and the <a>predicate</a> expressing such an event. <i>Example</i>: in <i>Sandy said, <dq>I'm buying the house</dq>, said</i> denotes the utterance event. Some predicates denoting utterance events include the <u>addressee</u> as an <a>argument</a>, as in <i>Sandy told me that she's buying the house</i>. (Section 18.2.2)
+    an <a>event</a> of saying in which one <a>participant</a> is the <u>speaker</u> of the utterance and another participant is the utterance itself. <i>Example</i>: in <i>Sandy said, <dq>I'm buying the house</dq>, said</i> denotes the utterance event. (Section 18.2.2)
 
 - Id: utterance predicate [cxn]
   Type: cxn
-  InstanceOf: utterance event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - utterance predicate
   SubtypeOf:
     - complement-taking predicate [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>predicate</a> expressing such an <a>utterance event</a>. <i>Example</i>: in <i>Sandy said, <dq>I'm buying the house</dq>, said</i> denotes the utterance event. Some predicates denoting utterance events include the <u>addressee</u> as an <a>argument</a>, as in <i>Sandy told me that she's buying the house</i>. (Section 18.2.2)
 
 - Id: vague numeral [cxn]
   Type: cxn
@@ -11268,7 +10440,7 @@
 
 - Id: wishing event [sem]
   Type: sem
-  InstanceOf: wishing event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - wishing event
   SubtypeOf:
@@ -11276,28 +10448,19 @@
   AssociatedTo:
     - evaluative predicate [cxn]
     - negative epistemic stance [sem]
-  Definition: ""
-
-- Id: wishing event [sem] / predicate [cxn]
-  Type: sem/cxn
-  InstanceOf: ""
-  Alias:
-    - wishing event/predicate
-    - wishing
-  SubtypeOf: []
-  AssociatedTo: []
   Definition: >-
-    an <a>evaluative event</a> in which a positive evaluative judgment about a <a>proposition</a> expressed by the <a>complement</a> of the wishing event is made, and there is a <a>negative epistemic stance</a> by the speaker toward the proposition; and the <a>predicate</a> expressing such an event. <i>Example</i>: in <i>Jill wishes that Joe had won the election</i>, the wishing predicate <i>wishes</i> expresses Jill's evaluation of Joe's winning the election, and also presupposes that the speaker believes that Joe didn't win the election. (Section 18.2.2)
+    an <a>evaluative event</a> in which a positive evaluative judgment about a <a>proposition</a> expressed by the <a>complement</a> of the wishing event is made, and there is a <a>negative epistemic stance</a> by the speaker toward the proposition. <i>Example</i>: in <i>Jill wishes that Joe had won the election</i>, the wishing predicate <i>wishes</i> expresses Jill's evaluation of Joe's winning the election, and also presupposes that the speaker believes that Joe didn't win the election. (Section 18.2.2)
 
 - Id: wishing predicate [cxn]
   Type: cxn
-  InstanceOf: wishing event [sem] / predicate [cxn]
+  InstanceOf: ""
   Alias:
     - wishing predicate
   SubtypeOf:
     - evaluative predicate [cxn]
   AssociatedTo: []
-  Definition: ""
+  Definition: >-
+    the <a>predicate</a> expressing a <a>wishing event</a>. <i>Example</i>: in <i>Jill wishes that Joe had won the election</i>, the wishing predicate <i>wishes</i> expresses Jill's evaluation of Joe's winning the election, and also presupposes that the speaker believes that Joe didn't win the election. (Section 18.2.2)
 
 - Id: with-possessive strategy [str]
   Type: str

--- a/cc-database.yaml
+++ b/cc-database.yaml
@@ -2874,7 +2874,7 @@
     - article [cxn]
   AssociatedTo: []
   Definition: >-
-    this term is applied to <a>referring phrases</a> -- <a>pronouns</a> and <a>articles</a> combined with <a>nouns</a> -- that are associated with the top end of the <a>information status</a> continuum, where the identity of the referent is already known to both speaker and hearer. This includes <a>active</a>, <a>semi-active</a>, <a>inactive</a>, and <a>inferrable</a> referents. <i>Example</i>: <i>the glass bowl</i> is an example of a definite referring phrase, used in a context where the individual glass bowl in question is identifiable by both speaker and hearer (Table 3.4, Section 3.3.1)
+    an <a>article</a> that is associated with the top end of the <a>information status</a> continuum, where the identity of the <a>referent</a> is already known to both speaker and hearer. This includes <a>active</a>, <a>semi-active</a>, <a>inactive</a>, and <a>inferrable</a> referents. <i>Example</i>: <i>the bowl</i> is an example of a definite referring phrase with a definite article <i>the</i> combined with a <a>common noun</a> bowl, used in a context where the individual bowl in question is identifiable by both speaker and hearer. (Table 3.4, Section 3.3.1)
 
 - Id: definite pronoun [cxn]
   Type: cxn
@@ -2885,7 +2885,7 @@
     - pronoun [cxn]
   AssociatedTo: []
   Definition: >-
-    this term is applied to <a>referring phrases</a> -- <a>pronouns</a> and <a>articles</a> combined with <a>nouns</a> -- that are associated with the top end of the <a>information status</a> continuum, where the identity of the referent is already known to both speaker and hearer. This includes <a>active</a>, <a>semi-active</a>, <a>inactive</a>, and <a>inferrable</a> referents. <i>Example</i>: <i>the glass bowl</i> is an example of a definite referring phrase, used in a context where the individual glass bowl in question is identifiable by both speaker and hearer (Table 3.4, Section 3.3.1)
+    a <a>pronoun</a> that is associated with the top end of the <a>information status</a> continuum, where the identity of the <a>referent</a> is already known to both speaker and hearer. This includes <a>active</a>, <a>semi-active</a>, <a>inactive</a>, and <a>inferrable</a> referents. <i>Example</i>: in <i>It is under the bed</i>, <i>it</i> is an example of a definite pronoun, used in a context where the referent of it is identifiable by both speaker and hearer. (Table 3.4, Section 3.3.1)
 
 - Id: degree [sem]
   Type: sem
@@ -4940,7 +4940,7 @@
     - article [cxn]
   AssociatedTo: []
   Definition: >-
-    this term is applied to <a>referring phrases</a> -- <a>pronouns</a> and <a>articles</a> combined with <a>nouns</a> -- that are associated with the bottom end of the <a>information status</a> continuum, where the identity of the referent is not known to speaker or hearer (or both). This includes <a>pragmatically specific</a>, <a>pragmatically nonspecific (but semantically specific)</a>, and various categories of <a>nonspecific referents</a> (see Table 3.4 and Sections 3.4--3.5). <i>Example</i>: <i>a glass bowl</i> is an example of an indefinite referring phrase, used in a context where the individual glass bowl in question is not identifiable by the hearer. (Table 3.4, Section 3.3.1)
+    an <a>article</a> that is associated with the bottom end of the <a>information status</a> continuum, where the identity of the referent is not known to speaker or hearer (or both). This includes <a>pragmatically specific</a>, <a>pragmatically nonspecific (but semantically specific)</a>, and various categories of <a>nonspecific referents</a> (see Table 3.4 and Sections 3.4–3.5). <i>Example</i>: <i>a bowl</i> is an example of an indefinite article <i>a</i> combined with a <a>common noun</a> bowl, used in a context where the individual bowl in question is not identifiable by the hearer. (Table 3.4, Section 3.3.1) 
 
 - Id: indefinite pronoun [cxn]
   Type: cxn
@@ -4951,7 +4951,7 @@
     - pronoun [cxn]
   AssociatedTo: []
   Definition: >-
-    this term is applied to <a>referring phrases</a> -- <a>pronouns</a> and <a>articles</a> combined with <a>nouns</a> -- that are associated with the bottom end of the <a>information status</a> continuum, where the identity of the referent is not known to speaker or hearer (or both). This includes <a>pragmatically specific</a>, <a>pragmatically nonspecific (but semantically specific)</a>, and various categories of <a>nonspecific referents</a> (see Table 3.4 and Sections 3.4--3.5). <i>Example</i>: <i>a glass bowl</i> is an example of an indefinite referring phrase, used in a context where the individual glass bowl in question is not identifiable by the hearer. (Table 3.4, Section 3.3.1)
+    a <a>pronoun</a> that is associated with the bottom end of the <a>information status</a> continuum, where the identity of the <a>referent</a> is not known to speaker or hearer (or both). This includes <a>pragmatically specific</a>, <a>pragmatically nonspecific (but semantically specific)</a>, and various categories of <a>nonspecific referents</a> (see Table 3.4 and Sections 3.4–3.5). <i>Example</i>: in <i>Something is under the bed</i>, <i>something</i> is an example of an indefinite pronoun, used in a context where the referent is not identifiable by the hearer. (Table 3.4, Section 3.3.1) 
 
 - Id: independent referring phrase strategy [str]
   Type: str

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,8 +7,8 @@
 <div id="search"></div>
 <h1><a href="#">Database of Comparative Concepts</a></h1>
 <p>Extracted from the appendix of <em>Morphosyntax: Constructions of the World's Languages</em>, by William Croft (2022)
-<p><strong>Build date/time:</strong> 2023-05-30 09:27:49</p>
-<p><strong>Statistics:</strong> 965 CCs, and 3647 links within CC definitions</p>
+<p><strong>Build date/time:</strong> 2023-07-07 15:41:37</p>
+<p><strong>Statistics:</strong> 868 CCs, and 3793 links within CC definitions</p>
 <div id="glosses">
 <div class="cc" id="A-role-(sem)">
 <h2 class="name"><a href="#A-role-(sem)">A role (<i>sem</i>)</a></h2>
@@ -428,7 +428,7 @@
 <strong>adjective impersonal strategy (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-event-(sem)-verb-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is expressed like an <a href="#adjective-(cxn)">adjective</a> (<a href="#property-concept-(sem)">property</a> <span class="separation"/> <a href="#modifier-(cxn)">modifier</a>) in an <a href="#argument-phrase-(cxn)">argument phrase</a> that does not <a href="#index-(str)">index</a> an <a href="#argument-(inf)">argument</a> of the <a href="#event-(sem)">event</a> <span class="separation"/> <a href="#predicate-(cxn)">predicate</a> in the complex predicate construction. <em>Example</em>: in Manchu <em>sargan jui hocikon ucule-he</em> <q>The girl sang beautifully</q>, <em>hocikon</em> <q>beautifully</q> does not index <em>sargan jui</em> <q>girl</q>. (Section 14.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-complex-predicate-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is expressed like an <a href="#adjective-(cxn)">adjective</a> (<a href="#property-concept-(sem)">property</a> <span class="separation"/> <a href="#modifier-(cxn)">modifier</a>) in an <a href="#argument-phrase-(cxn)">argument phrase</a> that does not <a href="#index-(str)">index</a> an <a href="#argument-(inf)">argument</a> of the <a href="#event-(sem)">event</a> <span class="separation"/> <a href="#predicate-(cxn)">predicate</a> in the complex predicate construction. <em>Example</em>: in Manchu <em>sargan jui hocikon ucule-he</em> <q>The girl sang beautifully</q>, <em>hocikon</em> <q>beautifully</q> does not index <em>sargan jui</em> <q>girl</q>. (Section 14.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="adjective-personal-strategy-(str)">
@@ -447,7 +447,7 @@
 <strong>adjective personal strategy (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-event-(sem)-verb-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is expressed like an <a href="#adjective-(cxn)">adjective</a> (<a href="#property-concept-(sem)">property</a> <span class="separation"/> <a href="#modifier-(cxn)">modifier</a>) in an <a href="#argument-phrase-(cxn)">argument phrase</a> that <a href="#index-(str)">indexes</a> an <a href="#argument-(inf)">argument</a> of the <a href="#event-(sem)">event</a> <span class="separation"/> <a href="#predicate-(cxn)">predicate</a> in the complex predicate construction. <em>Example</em>: in Latin <em>mendicus a me tristis stipem petivit</em> <q>The beggar asked me sadly for a gift</q>, the form <em>tristis</em> <q>sadly</q> indexes the subject <em>mendicus</em> <q>beggar</q> in <a href="#case-(sem)">case</a>, <a href="#number-(sem)">number</a> and <a href="#gender-class-(sem)">gender/class</a>. (Section 14.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-complex-predicate-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is expressed like an <a href="#adjective-(cxn)">adjective</a> (<a href="#property-concept-(sem)">property</a> <span class="separation"/> <a href="#modifier-(cxn)">modifier</a>) in an <a href="#argument-phrase-(cxn)">argument phrase</a> that <a href="#index-(str)">indexes</a> an <a href="#argument-(inf)">argument</a> of the <a href="#event-(sem)">event</a> <span class="separation"/> <a href="#predicate-(cxn)">predicate</a> in the complex predicate construction. <em>Example</em>: in Latin <em>mendicus a me tristis stipem petivit</em> <q>The beggar asked me sadly for a gift</q>, the form <em>tristis</em> <q>sadly</q> indexes the subject <em>mendicus</em> <q>beggar</q> in <a href="#case-(sem)">case</a>, <a href="#number-(sem)">number</a> and <a href="#gender-class-(sem)">gender/class</a>. (Section 14.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="adjoined-strategy-(str)">
@@ -596,7 +596,7 @@
 <strong>adpositional strategy (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-event-(sem)-verb-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is expressed with a <a href="#flag,-flagging-(str)">case marker</a> just like an <a href="#argument-phrase-(cxn)">argument phrase</a>, either in the basic lexical form or in a nominalized form of the stative concept word. <em>Example</em>: in Mordvin <em>t'ejt'er-es mor-i mazi-ste</em> <q>The girls sings beautifully</q>, <em>mazi</em> <q>beautiful</q> takes the Elative <a href="#oblique-phrase-(cxn)">oblique</a> flag <em>-ste</em>. (Section 14.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-complex-predicate-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is expressed with a <a href="#flag,-flagging-(str)">case marker</a> just like an <a href="#argument-phrase-(cxn)">argument phrase</a>, either in the basic lexical form or in a nominalized form of the stative concept word. <em>Example</em>: in Mordvin <em>t'ejt'er-es mor-i mazi-ste</em> <q>The girls sings beautifully</q>, <em>mazi</em> <q>beautiful</q> takes the Elative <a href="#oblique-phrase-(cxn)">oblique</a> flag <em>-ste</em>. (Section 14.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="adverbial-clause-construction-(cxn)">
@@ -658,7 +658,7 @@
 <strong>adverbial strategy (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-event-(sem)-verb-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is expressed using a distinct and unique <a href="#morphosyntax-(def)">morphosyntactic</a> form. <em>Example</em>: in English <em>The girl sang beautiful-ly</em>, <em>beautiful</em> uses the unique suffix <em>-ly</em> to combine with the <a href="#event-(sem)">event</a> <span class="separation"/> <a href="#predicate-(cxn)">predicate</a> <em>sang</em>. The adverbial strategy is probably a more <a href="#grammaticalization-(def)">grammaticalized</a> version of other strategies for stative complex predicates. (Section 14.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-complex-predicate-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is expressed using a distinct and unique <a href="#morphosyntax-(def)">morphosyntactic</a> form. <em>Example</em>: in English <em>The girl sang beautiful-ly</em>, <em>beautiful</em> uses the unique suffix <em>-ly</em> to combine with the <a href="#event-(sem)">event</a> <span class="separation"/> <a href="#predicate-(cxn)">predicate</a> <em>sang</em>. The adverbial strategy is probably a more <a href="#grammaticalization-(def)">grammaticalized</a> version of other strategies for stative complex predicates. (Section 14.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="adverbializer-(str)">
@@ -699,14 +699,8 @@
 <div class="cc" id="affecting-event-(sem)">
 <h2 class="name"><a href="#affecting-event-(sem)">affecting event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#affecting-event-(sem)-verb-(cxn)">affecting event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>affecting event (<i>sem</i>)</strong></span><span><a href="#affecting-verb-(cxn)">affecting verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">affecting event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">affecting event | affecting</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#stimulus-oriented-strategy-(str)">stimulus-oriented strategy (<i>str</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -717,31 +711,12 @@
 <strong>affecting event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="affecting-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#affecting-event-(sem)-verb-(cxn)">affecting event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>affecting event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#affecting-event-(sem)">affecting event (<i>sem</i>)</a></span><span><a href="#affecting-verb-(cxn)">affecting verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">affecting event/verb | affecting</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#experiential-event-(sem)">experiential event</a> which describes the <a href="#stimulus-(sem)">stimulus</a> causing a change in mental state of the <a href="#experiencer-(sem)">experiencer</a>; and a <a href="#verb-(cxn)">verb</a> that expresses such an event. <em>Example</em>: <em>The dog surprised me</em> is an instance of an affecting event, and <em>surprise</em> is an affecting verb. (Section 7.4)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#experiential-event-(sem)">experiential event</a> which describes the <a href="#stimulus-(sem)">stimulus</a> causing a change in mental state of the <a href="#experiencer-(sem)">experiencer</a>. <em>Example</em>: <em>The dog surprised me</em> is an instance of an affecting event. (Section 7.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="affecting-verb-(cxn)">
 <h2 class="name"><a href="#affecting-verb-(cxn)">affecting verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#affecting-event-(sem)-verb-(cxn)">affecting event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#affecting-event-(sem)">affecting event (<i>sem</i>)</a></span><span><strong>affecting verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">affecting verb | affect</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -753,6 +728,7 @@
 <strong>affecting verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#verb-(cxn)">verb</a> that expresses an <a href="#affecting-event-(sem)">affecting event</a>. <em>Example</em>: <em>The dog surprised me</em> is an instance of an affecting event, and <em>surprise</em> is an affecting verb. (Section 7.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="affixation-(str)">
@@ -809,12 +785,6 @@
 <div class="cc" id="agentive-change-of-state-event-(sem)">
 <h2 class="name"><a href="#agentive-change-of-state-event-(sem)">agentive change of state event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#agentive-change-of-state-event-(sem)-verb-(cxn)">agentive change of state event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>agentive change of state event (<i>sem</i>)</strong></span><span><a href="#agentive-change-of-state-verb-(cxn)">agentive change of state verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">agentive change of state event</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#bivalent-event-(sem)">bivalent event (<i>sem</i>)</a></td></tr>
@@ -827,31 +797,12 @@
 <strong>agentive change of state event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="agentive-change-of-state-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#agentive-change-of-state-event-(sem)-verb-(cxn)">agentive change of state event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>agentive change of state event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#agentive-change-of-state-event-(sem)">agentive change of state event (<i>sem</i>)</a></span><span><a href="#agentive-change-of-state-verb-(cxn)">agentive change of state verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">agentive change of state event/verb | agentive change of state</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#change-of-state-event-(sem)">change of state event</a> in which an external volitional <a href="#agent-(sem)">agent</a> brings about a change in a <a href="#patient-(sem)">patient</a> such that the patient enters a resulting <a href="#state-(sem)">state</a>; and the <a href="#verb-(cxn)">verb</a> that expresses such an event. <em>Example</em>: the event of a person drying dishes is an agentive change of state event, and <em>dry</em> is an agentive change of state verb. (Section 6.2.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#change-of-state-event-(sem)">change of state event</a> in which an external volitional <a href="#agent-(sem)">agent</a> brings about a change in a <a href="#patient-(sem)">patient</a> such that the patient enters a resulting <a href="#state-(sem)">state</a>. <em>Example</em>: the event of a person drying dishes is an agentive change of state event. (Section 6.2.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="agentive-change-of-state-verb-(cxn)">
 <h2 class="name"><a href="#agentive-change-of-state-verb-(cxn)">agentive change of state verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#agentive-change-of-state-event-(sem)-verb-(cxn)">agentive change of state event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#agentive-change-of-state-event-(sem)">agentive change of state event (<i>sem</i>)</a></span><span><strong>agentive change of state verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">agentive change of state verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -863,6 +814,7 @@
 <strong>agentive change of state verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#verb-(cxn)">verb</a> that expresses an agentive change of state event. <em>Example</em>: the event of a person drying dishes is an agentive change of state event, and <em>dry</em> is an agentive change of state verb. (Section 6.2.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="agree-disagree-alignment-strategy-(str)">
@@ -1019,12 +971,6 @@
 <div class="cc" id="alternative-question-(cxn)">
 <h2 class="name"><a href="#alternative-question-(cxn)">alternative question (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#alternative-question-(inf-cxn)">alternative question (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>alternative question (<i>cxn</i>)</strong></span><span><a href="#alternative-question-(inf)">alternative question (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">alternative question</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -1036,33 +982,14 @@
 <strong>alternative question (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="alternative-question-(inf-cxn)">
-<h2 class="name"><a href="#alternative-question-(inf-cxn)">alternative question (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>alternative question (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#alternative-question-(cxn)">alternative question (<i>cxn</i>)</a></span><span><a href="#alternative-question-(inf)">alternative question (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">alternative question</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an interrogative in which the speaker offers a closed list of alternatives to fill in the unknown piece of information in the propositional content; and the construction expressing this function. <em>Example</em>: <em>Do you prefer beer or wine?</em> is an instance of an alternative question construction, where the alternatives offered are beer and wine. (Section 12.3.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a construction expressing the <a href="#alternative-question-(inf)">alternative question function</a>. <em>Example</em>: <em>Do you prefer beer or wine?</em> is an instance of an alternative question construction, where the alternatives offered are beer and wine. (Section 12.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="alternative-question-(inf)">
 <h2 class="name"><a href="#alternative-question-(inf)">alternative question (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#alternative-question-(inf-cxn)">alternative question (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#alternative-question-(cxn)">alternative question (<i>cxn</i>)</a></span><span><strong>alternative question (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">alternative question</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">alternative question | alternative question function</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -1072,6 +999,7 @@
 <strong>alternative question (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an interrogative in which the speaker offers a closed list of alternatives to fill in the unknown piece of information in the propositional content. <em>Example</em>: <em>Do you prefer beer or wine?</em> is an instance of an alternative question construction, where the alternatives offered are beer and wine. (Section 12.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="amount-term-(cxn)">
@@ -1390,14 +1318,8 @@
 <div class="cc" id="apodosis-(cxn)">
 <h2 class="name"><a href="#apodosis-(cxn)">apodosis (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#apodosis-(sem-cxn)">apodosis (<i>sem/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>apodosis (<i>cxn</i>)</strong></span><span><a href="#apodosis-(sem)">apodosis (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">apodosis</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">apodosis | apodosis clause</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -1407,56 +1329,33 @@
 <strong>apodosis (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="apodosis-(sem-cxn)">
-<h2 class="name"><a href="#apodosis-(sem-cxn)">apodosis (<i>sem/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>apodosis (<i>sem/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#apodosis-(cxn)">apodosis (<i>cxn</i>)</a></span><span><a href="#apodosis-(sem)">apodosis (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">apodosis | consequent</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#clause-(cxn)">clause</a> expressing the causally consequent <a href="#proposition-(sem)">proposition</a> in a <a href="#causal-(sem)">causal</a>, <a href="#conditional-relation-(sem)-construction-(cxn)">conditional</a>, <a href="#concessive-relation-(sem)-construction-(cxn)">concessive</a>, <a href="#concessive-conditional-relation-(sem)-construction-(cxn)">concessive conditional</a>, or <a href="#comparative-conditional-construction-(cxn)">comparative conditional construction</a>; or the proposition or event denoted by the clause. <em>Example</em>: in <em>If you press this button, the door will open</em>, <em>the door will open</em> is the apodosis; <em>If you press this button</em> is the <a href="#protasis-(sem)">protasis</a>. Since the conditional relations are defined in terms of both logical implication and causal relation, the semantic use of <q>apodosis</q> can be distinguished as <q>apodosis proposition</q> or <q>apodosis event</q>. (Section 17.3.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#clause-(cxn)">clause</a> expressing the causally consequent <a href="#proposition-(sem)">proposition</a> in a <a href="#causal-(sem)">causal</a>, <a href="#conditional-relation-(sem)">conditional</a>, <a href="#concessive-relation-(sem)">concessive</a>, <a href="#concessive-conditional-relation-(sem)">concessive conditional</a>, or <a href="#comparative-conditional-construction-(cxn)">comparative conditional construction</a>. <em>Example</em>: in <em>If you press this button, the door will open</em>, <em>the door will open</em> is the apodosis; <em>If you press this button</em> is the <a href="#protasis-(sem)">protasis</a>. (Section 17.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="apodosis-(sem)">
 <h2 class="name"><a href="#apodosis-(sem)">apodosis (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#apodosis-(sem-cxn)">apodosis (<i>sem/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#apodosis-(cxn)">apodosis (<i>cxn</i>)</a></span><span><strong>apodosis (<i>sem</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">apodosis</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">apodosis | consequent</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#conditional-relation-(sem)">conditional relation (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
+<span><a href="#event-(sem)">event (<i>sem</i>)</a></span>
 <span><a href="#proposition-(sem)">proposition (<i>sem</i>)</a></span>
 </td></tr>
 <tr><td>
 <strong>apodosis (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the proposition or event denoted by an <a href="#apodosis-(cxn)">apodosis clause</a>. <em>Example</em>: in <em>If you press this button, the door will open</em>, <em>the door will open</em> is the apodosis; <em>If you press this button</em> is the <a href="#protasis-(sem)">protasis</a>. Since the conditional relations are defined in terms of both logical implication and causal relation, the semantic use of <q>apodosis</q> can be distinguished as <q>apodosis proposition</q> or <q>apodosis event</q>. (Section 17.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="application-event-(sem)">
 <h2 class="name"><a href="#application-event-(sem)">application event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#application-event-(sem)-verb-(cxn)">application event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>application event (<i>sem</i>)</strong></span><span><a href="#application-verb-(cxn)">application verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">application event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">application event | application | putting event</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -1466,33 +1365,14 @@
 <strong>application event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="application-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#application-event-(sem)-verb-(cxn)">application event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>application event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#application-event-(sem)">application event (<i>sem</i>)</a></span><span><a href="#application-verb-(cxn)">application verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">application event/verb | application | putting event/verb</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> describing placing or applying one <a href="#object-phrase-(cxn)">object</a> onto (2-dimensional) or into (3-dimensional) another object; and the <a href="#verb-(cxn)">verb</a> expressing such an event. <em>Examples</em>: smearing (2-dimensional) and loading (3-dimensional) are application events. (Section 7.3.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> describing placing or applying one <a href="#object-phrase-(cxn)">object</a> onto (2-dimensional) or into (3-dimensional) another object. <em>Examples</em>: smearing (2-dimensional) and loading (3-dimensional) are application events. (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="application-verb-(cxn)">
 <h2 class="name"><a href="#application-verb-(cxn)">application verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#application-event-(sem)-verb-(cxn)">application event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#application-event-(sem)">application event (<i>sem</i>)</a></span><span><strong>application verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">application verb</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">application verb | putting verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -1503,6 +1383,7 @@
 <strong>application verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing an <a href="#application-event-(sem)">application event</a>. <em>Examples</em>: smearing (2-dimensional) and loading (3-dimensional) are application events. (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="applicative-construction-(cxn)">
@@ -1694,7 +1575,7 @@
 <strong>arrival (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the final phase of the <a href="#path-of-motion-event-(sem)-verb-(cxn)">path</a> in a <a href="#motion-event-(sem)">motion event</a>. <em>Example</em>: in <em>He went from the tree to the house</em>, the path oblique phrase <em>to the house</em> denotes the arrival phase of the motion event. (Section 14.4)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the final phase of the <a href="#path-of-motion-event-(sem)">path</a> in a <a href="#motion-event-(sem)">motion event</a>. <em>Example</em>: in <em>He went from the tree to the house</em>, the path oblique phrase <em>to the house</em> denotes the arrival phase of the motion event. (Section 14.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="article-(cxn)">
@@ -1827,14 +1708,8 @@
 <div class="cc" id="attending-event-(sem)">
 <h2 class="name"><a href="#attending-event-(sem)">attending event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#attending-event-(sem)-verb-(cxn)">attending event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>attending event (<i>sem</i>)</strong></span><span><a href="#attending-verb-(cxn)">attending verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">attending event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">attending event | attending</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#experiential-verb-(cxn)">experiential verb (<i>cxn</i>)</a> | <a href="#experiencer-oriented-strategy-(str)">experiencer-oriented strategy (<i>str</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -1845,31 +1720,12 @@
 <strong>attending event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="attending-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#attending-event-(sem)-verb-(cxn)">attending event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>attending event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#attending-event-(sem)">attending event (<i>sem</i>)</a></span><span><a href="#attending-verb-(cxn)">attending verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">attending event/verb | attending</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#experiential-event-(sem)">experiential event</a> which describes the <a href="#experiencer-(sem)">experiencer</a> directing her/his attention to the <a href="#stimulus-(sem)">stimulus</a>; and a <a href="#verb-(cxn)">verb</a> that expresses such an event. <em>Example</em>: <em>I am looking at the sandhill crane</em> is an instance of an attending event, and <em>look (at)</em> is an attending verb. (Section 7.4)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#experiential-event-(sem)">experiential event</a> which describes the <a href="#experiencer-(sem)">experiencer</a> directing her/his attention to the <a href="#stimulus-(sem)">stimulus</a>. <em>Example</em>: <em>I am looking at the sandhill crane</em> is an instance of an attending event. (Section 7.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="attending-verb-(cxn)">
 <h2 class="name"><a href="#attending-verb-(cxn)">attending verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#attending-event-(sem)-verb-(cxn)">attending event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#attending-event-(sem)">attending event (<i>sem</i>)</a></span><span><strong>attending verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">attending verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -1881,6 +1737,7 @@
 <strong>attending verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#verb-(cxn)">verb</a> that expresses an <a href="#attending-event-(sem)">attending event</a>. <em>Example</em>: <em>I am looking at the sandhill crane</em> is an instance of an attending event, and <em>look (at)</em> is an attending verb. (Section 7.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="attributive-phrase-(cxn)">
@@ -2102,7 +1959,7 @@
 <table>
 <tr><th>Type</th> <td class="ccinfo type">def</td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">Binding Hierarchy | Complement Deranking-Argument Hierarchy</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an implicational hierarchy of <a href="#event-(sem)">events</a> that have other events as <a href="#participant-(sem)">participants</a> (the <a href="#complement-dependent-clause-(cxn)">complement</a> events), which appears to govern a wide range of strategies for <a href="#complement-clause-construction-(cxn)">complement clause constructions</a>, including <a href="#balanced,-balancing-(str)">balancing</a> vs. <a href="#deranked,-deranking-(str)">deranking</a> (Section 18.3.1), the <a href="#grammaticalization-(def)">grammaticalization</a> of <a href="#purpose-(sem)">purpose</a> <span class="separation"/> <a href="#adverbial-clause-construction-(cxn)">adverbial clauses</a> into deranked <a href="#complement-dependent-clause-(cxn)">complements</a> (Section 18.3.2), the expression of the participants of the <a href="#complement-taking-predicate-(cxn)">complement-taking predicate</a> and complement events (Section 18.4.1), and the use of <a href="#logophoric-construction-(cxn)">logophoric constructions</a> (Section 18.4.2). The Binding Hierarchy is described in detail in Givón (1980) and Cristofaro (2003); the latter calls it the Complement Deranking – Argument Hierarchy. The version used here is a slightly revised version of Cristofaro's hierarchy: <a href="#utterance-event-(sem)-predicate-(cxn)">utterance</a>, <a href="#propositional-attitude-event-(sem)-predicate-(cxn)">propositional attitude</a>, <a href="#knowledge-event-(sem)-predicate-(cxn)">knowledge</a> &lt; <a href="#evaluative-event-(sem)-predicate-(cxn)">evaluative</a>, <a href="#perception-event-(sem)-verb-(cxn)-complement-taking-predicate-(cxn)">perception</a> &lt; <a href="#desiderative-event-(sem)-predicate-(cxn)">desiderative</a>, <a href="#manipulative-event-(sem)-predicate-(cxn)">manipulative</a> &lt; <a href="#modality-(sem)">modal</a>, <a href="#phasal-aspect-(sem)">phasal</a>. (Section 18.3.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an implicational hierarchy of <a href="#event-(sem)">events</a> that have other events as <a href="#participant-(sem)">participants</a> (the <a href="#complement-dependent-clause-(cxn)">complement</a> events), which appears to govern a wide range of strategies for <a href="#complement-clause-construction-(cxn)">complement clause constructions</a>, including <a href="#balanced,-balancing-(str)">balancing</a> vs. <a href="#deranked,-deranking-(str)">deranking</a> (Section 18.3.1), the <a href="#grammaticalization-(def)">grammaticalization</a> of <a href="#purpose-(sem)">purpose</a> <span class="separation"/> <a href="#adverbial-clause-construction-(cxn)">adverbial clauses</a> into deranked <a href="#complement-dependent-clause-(cxn)">complements</a> (Section 18.3.2), the expression of the participants of the <a href="#complement-taking-predicate-(cxn)">complement-taking predicate</a> and complement events (Section 18.4.1), and the use of <a href="#logophoric-construction-(cxn)">logophoric constructions</a> (Section 18.4.2). The Binding Hierarchy is described in detail in Givón (1980) and Cristofaro (2003); the latter calls it the Complement Deranking – Argument Hierarchy. The version used here is a slightly revised version of Cristofaro's hierarchy: <a href="#utterance-event-(sem)">utterance</a>, <a href="#propositional-attitude-event-(sem)">propositional attitude</a>, <a href="#knowledge-event-(sem)">knowledge</a> &lt; <a href="#evaluative-event-(sem)">evaluative</a>, <a href="#perception-event-(sem)">perception</a> &lt; <a href="#desiderative-event-(sem)">desiderative</a>, <a href="#manipulative-event-(sem)">manipulative</a> &lt; <a href="#modality-(sem)">modal</a>, <a href="#phasal-aspect-(sem)">phasal</a>. (Section 18.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="binominal-lexeme-construction-(cxn)">
@@ -2160,14 +2017,8 @@
 <div class="cc" id="bodily-action-(sem)">
 <h2 class="name"><a href="#bodily-action-(sem)">bodily action (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#bodily-action-(sem)-predicate-(cxn)">bodily action (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>bodily action (<i>sem</i>)</strong></span><span><a href="#bodily-predicate-(cxn)">bodily predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">bodily action</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">bodily | bodily action</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -2177,31 +2028,12 @@
 <strong>bodily action (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="bodily-action-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#bodily-action-(sem)-predicate-(cxn)">bodily action (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>bodily action (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#bodily-action-(sem)">bodily action (<i>sem</i>)</a></span><span><a href="#bodily-predicate-(cxn)">bodily predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">bodily action/predicate | bodily</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#event-(sem)">event</a> class of normally uncontrolled actions involving one's body; and the <a href="#predicate-(cxn)">predicates</a> that express events in this class. <em>Example</em>: coughing is a bodily action, and <em>cough</em> is a bodily action predicate. (Section 6.3.3)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#event-(sem)">event</a> class of normally uncontrolled actions involving one's body. <em>Example</em>: coughing is a bodily action. (Section 6.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="bodily-motion-event-(sem)">
 <h2 class="name"><a href="#bodily-motion-event-(sem)">bodily motion event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#bodily-motion-event-(sem)-verb-(cxn)">bodily motion event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>bodily motion event (<i>sem</i>)</strong></span><span><a href="#bodily-motion-verb-(cxn)">bodily motion verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">bodily motion event</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#middle-voice-(str)">middle voice (<i>str</i>)</a></td></tr>
@@ -2214,31 +2046,12 @@
 <strong>bodily motion event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="bodily-motion-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#bodily-motion-event-(sem)-verb-(cxn)">bodily motion event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>bodily motion event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#bodily-motion-event-(sem)">bodily motion event (<i>sem</i>)</a></span><span><a href="#bodily-motion-verb-(cxn)">bodily motion verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">bodily motion event/verb | bodily motion</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#monovalent-event-(sem)">monovalent event</a> involving an internal bodily motion; and the <a href="#verb-(cxn)">verb</a> expressing that event. <em>Example</em>: <em>stretch out (oneself)</em> expresses a bodily motion event. (Section 7.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#monovalent-event-(sem)">monovalent event</a> involving an internal bodily motion. <em>Example</em>: <em>stretch out (oneself)</em> expresses a bodily motion event. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="bodily-motion-verb-(cxn)">
 <h2 class="name"><a href="#bodily-motion-verb-(cxn)">bodily motion verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#bodily-motion-event-(sem)-verb-(cxn)">bodily motion event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#bodily-motion-event-(sem)">bodily motion event (<i>sem</i>)</a></span><span><strong>bodily motion verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">bodily motion verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -2250,17 +2063,12 @@
 <strong>bodily motion verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing a <a href="#bodily-motion-event-(sem)">bodily motion event</a>. <em>Example</em>: <em>stretch out (oneself)</em> expresses a bodily motion event. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="bodily-predicate-(cxn)">
 <h2 class="name"><a href="#bodily-predicate-(cxn)">bodily predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#bodily-action-(sem)-predicate-(cxn)">bodily action (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#bodily-action-(sem)">bodily action (<i>sem</i>)</a></span><span><strong>bodily predicate (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">bodily predicate</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -2272,19 +2080,14 @@
 <strong>bodily predicate (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#predicate-(cxn)">predicates</a> that express events in the <a>bodily action<a> event class. <em>Example</em>: coughing is a bodily action, and <em>cough</em> is a bodily action predicate. (Section 6.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="body-care-event-(sem)">
 <h2 class="name"><a href="#body-care-event-(sem)">body care event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#body-care-event-(sem)-verb-(cxn)">body care event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>body care event (<i>sem</i>)</strong></span><span><a href="#body-care-verb-(cxn)">body care verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">body care event | grooming event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">body care event | body care | grooming event</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#middle-voice-(str)">middle voice (<i>str</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -2295,31 +2098,12 @@
 <strong>body care event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="body-care-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#body-care-event-(sem)-verb-(cxn)">body care event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>body care event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#body-care-event-(sem)">body care event (<i>sem</i>)</a></span><span><a href="#body-care-verb-(cxn)">body care verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">body care event/verb | body care | grooming event/verb</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#monovalent-event-(sem)">monovalent event</a> involving a person acting on that person's own body, generally for grooming or hygiene; and the <a href="#verb-(cxn)">verb</a> expressing that event. <em>Examples</em>: <em>shave</em> and <em>wash (oneself)</em> express body care events. (Section 7.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#monovalent-event-(sem)">monovalent event</a> involving a person acting on that person's own body, generally for grooming or hygiene. <em>Examples</em>: <em>shave</em> and <em>wash (oneself)</em> express body care events. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="body-care-verb-(cxn)">
 <h2 class="name"><a href="#body-care-verb-(cxn)">body care verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#body-care-event-(sem)-verb-(cxn)">body care event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#body-care-event-(sem)">body care event (<i>sem</i>)</a></span><span><strong>body care verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">body care verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -2331,6 +2115,7 @@
 <strong>body care verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing a <a href="#body-care-event-(sem)">body care event</a>. <em>Examples</em>: <em>shave</em> and <em>wash (oneself)</em> express body care events. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="body-part-relation-(sem)">
@@ -2353,14 +2138,8 @@
 <div class="cc" id="body-position-event-(sem)">
 <h2 class="name"><a href="#body-position-event-(sem)">body position event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#body-position-event-(sem)-predicate-(cxn)">body position event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>body position event (<i>sem</i>)</strong></span><span><a href="#body-position-predicate-(cxn)">body position predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">body position event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">body position event | body position | posture event | posture | maintain position event | maintain position | locative stative event | locative stative</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -2370,33 +2149,14 @@
 <strong>body position event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="body-position-event-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#body-position-event-(sem)-predicate-(cxn)">body position event (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>body position event (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#body-position-event-(sem)">body position event (<i>sem</i>)</a></span><span><a href="#body-position-predicate-(cxn)">body position predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">body position event/predicate | body position | posture event/predicate | maintain position event/predicate | locative stative event/predicate | locative stative | maintain position | posture</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the event class of maintaining a particular body posture or position; and the <a href="#predicate-(cxn)">predicates</a> that express events in this class. <em>Example</em>: standing is a body position event, and <em>stand</em> is a body position predicate. (Section 6.3.3)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the event class of maintaining a particular body posture or position. <em>Example</em>: standing is a body position event. (Section 6.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="body-position-predicate-(cxn)">
 <h2 class="name"><a href="#body-position-predicate-(cxn)">body position predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#body-position-event-(sem)-predicate-(cxn)">body position event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#body-position-event-(sem)">body position event (<i>sem</i>)</a></span><span><strong>body position predicate (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">body position predicate</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">body position predicate | body position | posture predicate | posture | maintain position predicate | maintain position | locative stative predicate | locative stative</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -2406,6 +2166,7 @@
 <strong>body position predicate (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#predicate-(cxn)">predicates</a> that express events in the <a href="#body-position-event-(sem)">body position event</a> class. <em>Example</em>: standing is a body position event, and <em>stand</em> is a body position predicate. (Section 6.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="cardinal-numeral-(cxn)">
@@ -2481,7 +2242,7 @@
 <span><a href="#speech-act-causal-relation-(sem)">speech act causal relation (<i>sem</i>)</a></span>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the semantic relation between two <a href="#event-(sem)">events</a> where one event causes the other. <em>Example</em>: <em>I left the party because I was tired</em> is a <a href="#figure-ground-(inf)">figure–ground construal</a> of the simultaneous relation in an <a href="#adverbial-clause-construction-(cxn)">adverbial clause construction</a>, and <em>I was tired and (so) I left the party</em> is a <a href="#complex-figure-(inf)">complex figure construal</a> of the relation in a <a href="#coordinate-clause-construction-(cxn)">coordinate clause construction</a>. In the figure–ground construal, the causing event (the <a href="#protasis-(sem)">protasis</a>; Section 17.3.2) is construed as the ground, and expressed in the <a href="#adverbial-dependent-clause-(cxn)">adverbial dependent clause</a>. Causal relations also occur in <a href="#conditional-relation-(sem)-construction-(cxn)">conditional</a>, <a href="#concessive-relation-(sem)-construction-(cxn)">concessive</a>, <a href="#concessive-conditional-relation-(sem)-construction-(cxn)">concessive conditional</a>, and <a href="#comparative-conditional-construction-(cxn)">comparative conditional constructions</a>. Causal relations are divided into <a href="#content-causal-relation-(sem)">content</a>, <a href="#epistemic-causal-relation-(sem)">epistemic</a>, and <a href="#speech-act-causal-relation-(sem)">speech act relations</a>. (Sections 15.3.1, 17.2.1, 17.3.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the semantic relation between two <a href="#event-(sem)">events</a> where one event causes the other. <em>Example</em>: <em>I left the party because I was tired</em> is a <a href="#figure-ground-(inf)">figure–ground construal</a> of the simultaneous relation in an <a href="#adverbial-clause-construction-(cxn)">adverbial clause construction</a>, and <em>I was tired and (so) I left the party</em> is a <a href="#complex-figure-(inf)">complex figure construal</a> of the relation in a <a href="#coordinate-clause-construction-(cxn)">coordinate clause construction</a>. In the figure–ground construal, the causing event (the <a href="#protasis-(sem)">protasis</a>; Section 17.3.2) is construed as the ground, and expressed in the <a href="#adverbial-dependent-clause-(cxn)">adverbial dependent clause</a>. Causal relations also occur in <a href="#conditional-relation-(sem)">conditional</a>, <a href="#concessive-relation-(sem)">concessive</a>, <a href="#concessive-conditional-relation-(sem)">concessive conditional</a>, and <a href="#comparative-conditional-construction-(cxn)">comparative conditional constructions</a>. Causal relations are divided into <a href="#content-causal-relation-(sem)">content</a>, <a href="#epistemic-causal-relation-(sem)">epistemic</a>, and <a href="#speech-act-causal-relation-(sem)">speech act relations</a>. (Sections 15.3.1, 17.2.1, 17.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="causal-chain-(sem)">
@@ -2695,12 +2456,6 @@
 <div class="cc" id="chaining-construction-(cxn)">
 <h2 class="name"><a href="#chaining-construction-(cxn)">chaining construction (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#chaining-event-(sem)-construction-(cxn)">chaining event (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>chaining construction (<i>cxn</i>)</strong></span><span><a href="#chaining-event-(sem)">chaining event (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">chaining construction</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -2712,19 +2467,14 @@
 <strong>chaining construction (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> expressing such a <a href="#chaining-event-(sem)">chaining event</a>. <em>Example</em>: in <em>The guests followed one another into the room</em>, each guest is a follower and a <q class="dq">followee</q>, except the first and last in the chain. It is also possible to have a closed chain, as in people following each other in a circle, in which all participants are both initiator and endpoint. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="chaining-event-(sem)">
 <h2 class="name"><a href="#chaining-event-(sem)">chaining event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#chaining-event-(sem)-construction-(cxn)">chaining event (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#chaining-construction-(cxn)">chaining construction (<i>cxn</i>)</a></span><span><strong>chaining event (<i>sem</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">chaining event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">chaining event | chaining</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -2734,31 +2484,12 @@
 <strong>chaining event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="chaining-event-(sem)-construction-(cxn)">
-<h2 class="name"><a href="#chaining-event-(sem)-construction-(cxn)">chaining event (<i>sem</i>) / construction (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>chaining event (<i>sem</i>) / construction (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#chaining-construction-(cxn)">chaining construction (<i>cxn</i>)</a></span><span><a href="#chaining-event-(sem)">chaining event (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">chaining event/construction | chaining</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> type in which one <a href="#participant-(sem)">participant</a> acts upon another participant, and the second participant acts on a third participant in the same way, and so on; and the <a href="#construction-(def)">construction</a> expressing such an event. That is, each participant in the chain is both the <a href="#initiator-(sem)">initiator</a> and <a href="#endpoint-(sem)">endpoint</a> of <a href="#causal-structure-(sem)">transmission of force</a> for the same type of action – except the first in the chain, who is only an initiator, and the last, who is only an endpoint. <em>Example</em>: in <em>The guests followed one another into the room</em>, each guest is a follower and a <q class="dq">followee</q>, except the first and last in the chain. It is also possible to have a closed chain, as in people following each other in a circle, in which all participants are both initiator and endpoint. (Section 7.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> type in which one <a href="#participant-(sem)">participant</a> acts upon another participant, and the second participant acts on a third participant in the same way, and so on. That is, each participant in the chain is both the <a href="#initiator-(sem)">initiator</a> and <a href="#endpoint-(sem)">endpoint</a> of <a href="#causal-structure-(sem)">transmission of force</a> for the same type of action – except the first in the chain, who is only an initiator, and the last, who is only an endpoint. <em>Example</em>: in <em>The guests followed one another into the room</em>, each guest is a follower and a <q class="dq">followee</q>, except the first and last in the chain. It is also possible to have a closed chain, as in people following each other in a circle, in which all participants are both initiator and endpoint. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="change-in-body-position-event-(sem)">
 <h2 class="name"><a href="#change-in-body-position-event-(sem)">change in (body) position event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#change-in-body-position-event-(sem)-verb-(cxn)">change in (body) position event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>change in (body) position event (<i>sem</i>)</strong></span><span><a href="#change-in-body-position-verb-(cxn)">change in (body) position verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">change in (body) position event | change in body position event | change in position event | assume position event | change in posture event</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#middle-voice-(str)">middle voice (<i>str</i>)</a></td></tr>
@@ -2771,31 +2502,12 @@
 <strong>change in (body) position event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="change-in-body-position-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#change-in-body-position-event-(sem)-verb-(cxn)">change in (body) position event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>change in (body) position event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#change-in-body-position-event-(sem)">change in (body) position event (<i>sem</i>)</a></span><span><a href="#change-in-body-position-verb-(cxn)">change in (body) position verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">change in (body) position event/verb | change in (body) position | change in body position | change in position | assume position | change in posture</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#monovalent-event-(sem)">monovalent event</a> involving a person changing their bodily position; and the <a href="#verb-(cxn)">verb</a> expressing that event. <em>Example</em>: <em>sit</em> and <em>lean</em> express change in body posture events. (Section 7.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#monovalent-event-(sem)">monovalent event</a> involving a person changing their bodily position. <em>Example</em>: <em>sit</em> and <em>lean</em> express change in body posture events. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="change-in-body-position-verb-(cxn)">
 <h2 class="name"><a href="#change-in-body-position-verb-(cxn)">change in (body) position verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#change-in-body-position-event-(sem)-verb-(cxn)">change in (body) position event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#change-in-body-position-event-(sem)">change in (body) position event (<i>sem</i>)</a></span><span><strong>change in (body) position verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">change in (body) position verb | change in body position verb | change in position verb | assume position verb | change in posture verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -2807,19 +2519,14 @@
 <strong>change in (body) position verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing a <a href="#change-in-body-position-event-(sem)">change in body position event</a>. <em>Example</em>: <em>sit</em> and <em>lean</em> express change in body posture events. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="change-of-state-event-(sem)">
 <h2 class="name"><a href="#change-of-state-event-(sem)">change of state event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#change-of-state-event-(sem)-verb-(cxn)">change of state event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>change of state event (<i>sem</i>)</strong></span><span><a href="#change-of-state-verb-(cxn)">change of state verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">change of state event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">change of state event | change of state | COS event | COS</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#monovalent-event-(sem)">monovalent event (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -2833,20 +2540,7 @@
 <span><a href="#agentive-change-of-state-event-(sem)">agentive change of state event (<i>sem</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="change-of-state-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#change-of-state-event-(sem)-verb-(cxn)">change of state event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>change of state event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#change-of-state-event-(sem)">change of state event (<i>sem</i>)</a></span><span><a href="#change-of-state-verb-(cxn)">change of state verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">change of state event/verb | change of state | COS event/verb | COS</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> in which a <a href="#participant-(sem)">participant</a>, the <a href="#patient-(sem)">patient</a>, undergoes a change such that the patient enters a resulting <a href="#state-(sem)">state</a>, usually a change of physical state; and the <a href="#verb-(cxn)">verb</a> expressing that event. <em>Example</em>: the event of dishes becoming dry is a change of state event, and <em>dry</em> is a change of state verb. (Sections 6.1.2, <strong>6.2.1</strong>)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> in which a <a href="#participant-(sem)">participant</a>, the <a href="#patient-(sem)">patient</a>, undergoes a change such that the patient enters a resulting <a href="#state-(sem)">state</a>, usually a change of physical state. <em>Example</em>: the event of dishes becoming dry is a change of state event. (Sections 6.1.2, <strong>6.2.1</strong>)</td></tr>
 </table>
 </div>
 <div class="cc" id="change-of-state-verb-(cxn)">
@@ -2856,10 +2550,10 @@
 <table><tr><td class="flex"><span>
 <a href="#change-of-state-event-(sem)-verb-(cxn)">change of state event (<i>sem</i>) / verb (<i>cxn</i>)</a>
 </span></td></tr><tr><td class="flex"><span>
-<a href="#change-of-state-event-(sem)">change of state event (<i>sem</i>)</a></span><span><strong>change of state verb (<i>cxn</i>)</strong>
+<strong>change of state verb (<i>cxn</i>)</strong>
 </span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">change of state verb</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">change of state verb | COS verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -2872,6 +2566,7 @@
 <span><a href="#agentive-change-of-state-verb-(cxn)">agentive change of state verb (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing a <a href="#change-of-state-event-(sem)">change of state event</a>. <em>Example</em>: the event of dishes becoming dry is a change of state event, and <em>dry</em> is a change of state verb. (Sections 6.1.2, <strong>6.2.1</strong>)</td></tr>
 </table>
 </div>
 <div class="cc" id="choosing-(inf)">
@@ -3021,14 +2716,8 @@
 <div class="cc" id="cognition-event-(sem)">
 <h2 class="name"><a href="#cognition-event-(sem)">cognition event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#cognition-event-(sem)-verb-(cxn)">cognition event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>cognition event (<i>sem</i>)</strong></span><span><a href="#cognition-verb-(cxn)">cognition verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">cognition event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">cognition event | cognition</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -3038,31 +2727,12 @@
 <strong>cognition event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="cognition-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#cognition-event-(sem)-verb-(cxn)">cognition event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>cognition event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#cognition-event-(sem)">cognition event (<i>sem</i>)</a></span><span><a href="#cognition-verb-(cxn)">cognition verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">cognition event/verb | cognition</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#experiential-event-(sem)">experiential event</a> involving an <a href="#experiencer-(sem)">experiencer</a>'s cognition directed toward a <a href="#stimulus-(sem)">stimulus</a>; and a <a href="#verb-(cxn)">verb</a> that expresses such an event. <em>Example</em>: <em>Tim thought about the war</em> is an example of a cognition event, and <em>think (about)</em> is the cognition verb. (Section 7.4)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#experiential-event-(sem)">experiential event</a> involving an <a href="#experiencer-(sem)">experiencer</a>'s cognition directed toward a <a href="#stimulus-(sem)">stimulus</a>. <em>Example</em>: <em>Tim thought about the war</em> is an example of a cognition event. (Section 7.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="cognition-verb-(cxn)">
 <h2 class="name"><a href="#cognition-verb-(cxn)">cognition verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#cognition-event-(sem)-verb-(cxn)">cognition event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#cognition-event-(sem)">cognition event (<i>sem</i>)</a></span><span><strong>cognition verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">cognition verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -3074,17 +2744,12 @@
 <strong>cognition verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#verb-(cxn)">verb</a> that expresses a <a href="#cognition-event-(sem)">cognition event</a>. <em>Example</em>: <em>Tim thought about the war</em> is an example of a cognition event, and <em>think (about)</em> is the cognition verb. (Section 7.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="collective-construction-(cxn)">
 <h2 class="name"><a href="#collective-construction-(cxn)">collective construction (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#collective-event-(sem)-construction-(cxn)">collective event (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>collective construction (<i>cxn</i>)</strong></span><span><a href="#collective-event-(sem)">collective event (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">collective construction</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -3096,19 +2761,14 @@
 <strong>collective construction (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> expressing a <a href="#collective-event-(sem)">collective event</a>. <em>Example</em>: in <em>Mary and Sue left together</em>, Mary leaves and Sue leaves, and the two leaving events are connected. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="collective-event-(sem)">
 <h2 class="name"><a href="#collective-event-(sem)">collective event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#collective-event-(sem)-construction-(cxn)">collective event (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#collective-construction-(cxn)">collective construction (<i>cxn</i>)</a></span><span><strong>collective event (<i>sem</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">collective event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">collective event | collective</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#reciprocal-construction-(cxn)">reciprocal construction (<i>cxn</i>)</a> | <a href="#reflexive-construction-(cxn)">reflexive construction (<i>cxn</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -3119,20 +2779,7 @@
 <strong>collective event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="collective-event-(sem)-construction-(cxn)">
-<h2 class="name"><a href="#collective-event-(sem)-construction-(cxn)">collective event (<i>sem</i>) / construction (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>collective event (<i>sem</i>) / construction (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#collective-construction-(cxn)">collective construction (<i>cxn</i>)</a></span><span><a href="#collective-event-(sem)">collective event (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">collective event/construction | collective</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> type in which two <a href="#participant-(sem)">participants</a> both play the same role in two related events (that is, they do it <q class="dq">together</q>); and the <a href="#construction-(def)">construction</a> expressing such an event. <em>Example</em>: in <em>Mary and Sue left together</em>, Mary leaves and Sue leaves, and the two leaving events are connected. (Section 7.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> type in which two <a href="#participant-(sem)">participants</a> both play the same role in two related events (that is, they do it <q class="dq">together</q>). <em>Example</em>: in <em>Mary and Sue left together</em>, Mary leaves and Sue leaves, and the two leaving events are connected. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="color-term-(cxn)">
@@ -3155,14 +2802,8 @@
 <div class="cc" id="combining-event-(sem)">
 <h2 class="name"><a href="#combining-event-(sem)">combining event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#combining-event-(sem)-verb-(cxn)">combining event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>combining event (<i>sem</i>)</strong></span><span><a href="#combining-verb-(cxn)">combining verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">combining event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">combining event | combining</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -3172,31 +2813,12 @@
 <strong>combining event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="combining-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#combining-event-(sem)-verb-(cxn)">combining event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>combining event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#combining-event-(sem)">combining event (<i>sem</i>)</a></span><span><a href="#combining-verb-(cxn)">combining verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">combining event/verb | combining</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> describing the combining of two <a href="#object-phrase-(cxn)">objects</a>; and the <a href="#verb-(cxn)">verb</a> expressing such an event. <em>Example</em>: blending is a combining event. (Section 7.3.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> describing the combining of two <a href="#object-phrase-(cxn)">objects</a>. <em>Example</em>: blending is a combining event. (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="combining-verb-(cxn)">
 <h2 class="name"><a href="#combining-verb-(cxn)">combining verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#combining-event-(sem)-verb-(cxn)">combining event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#combining-event-(sem)">combining event (<i>sem</i>)</a></span><span><strong>combining verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">combining verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -3209,6 +2831,7 @@
 <strong>combining verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing a <a href="#combining-event-(sem)">combining event</a>. <em>Example</em>: blending is a combining event. (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="comitative-(sem)">
@@ -3249,14 +2872,8 @@
 <div class="cc" id="commentative-event-(sem)">
 <h2 class="name"><a href="#commentative-event-(sem)">commentative event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#commentative-event-(sem)-predicate-(cxn)">commentative event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>commentative event (<i>sem</i>)</strong></span><span><a href="#commentative-predicate-(cxn)">commentative predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">commentative event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">commentative event | commentative</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#factive-event-(sem)">factive event (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -3267,20 +2884,7 @@
 <strong>commentative event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="commentative-event-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#commentative-event-(sem)-predicate-(cxn)">commentative event (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>commentative event (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#commentative-event-(sem)">commentative event (<i>sem</i>)</a></span><span><a href="#commentative-predicate-(cxn)">commentative predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">commentative event/predicate | commentative</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#evaluative-event-(sem)">evaluative event</a> in which an evaluative judgment about a <a href="#proposition-(sem)">proposition</a> expressed by the <a href="#complement-dependent-clause-(cxn)">complement</a> of the commentative event is made, and there is a <a href="#positive-epistemic-stance-(sem)">positive epistemic stance</a> by the speaker toward the proposition; and the <a href="#predicate-(cxn)">predicate</a> expressing that event. <em>Example</em>: in <em>Nancy is glad that Joe won the election</em>, the commentative predicate <em>is glad</em> expresses Nancy's evaluation of Joe's winning the election, and also presupposes that the speaker believes that Joe indeed won the election. (Section 18.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#evaluative-event-(sem)">evaluative event</a> in which an evaluative judgment about a <a href="#proposition-(sem)">proposition</a> expressed by the <a href="#complement-dependent-clause-(cxn)">complement</a> of the commentative event is made, and there is a <a href="#positive-epistemic-stance-(sem)">positive epistemic stance</a> by the speaker toward the proposition. <em>Example</em>: in <em>Nancy is glad that Joe won the election</em>, the commentative predicate <em>is glad</em> expresses Nancy's evaluation of Joe's winning the election, and also presupposes that the speaker believes that Joe indeed won the election. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="commentative-predicate-(cxn)">
@@ -3290,7 +2894,7 @@
 <table><tr><td class="flex"><span>
 <a href="#commentative-event-(sem)-predicate-(cxn)">commentative event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
 </span></td></tr><tr><td class="flex"><span>
-<a href="#commentative-event-(sem)">commentative event (<i>sem</i>)</a></span><span><strong>commentative predicate (<i>cxn</i>)</strong>
+<strong>commentative predicate (<i>cxn</i>)</strong>
 </span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">commentative predicate</td></tr>
@@ -3303,6 +2907,7 @@
 <strong>commentative predicate (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#predicate-(cxn)">predicate</a> expressing a <a href="#commentative-event-(sem)">commentative event</a>. <em>Example</em>: in <em>Nancy is glad that Joe won the election</em>, the commentative predicate <em>is glad</em> expresses Nancy's evaluation of Joe's winning the election, and also presupposes that the speaker believes that Joe indeed won the election. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="common-noun-(cxn)">
@@ -3334,12 +2939,6 @@
 <div class="cc" id="comparative-conditional-construction-(cxn)">
 <h2 class="name"><a href="#comparative-conditional-construction-(cxn)">comparative conditional construction (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#comparative-conditional-relation-(sem)-construction-(cxn)">comparative conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>comparative conditional construction (<i>cxn</i>)</strong></span><span><a href="#comparative-conditional-relation-(sem)">comparative conditional relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">comparative conditional construction</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -3351,19 +2950,14 @@
 <strong>comparative conditional construction (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a construction that expresses a <a href="#comparative-conditional-relation-(sem)">comparative conditional relation</a>. <em>Example</em>: <em>The longer that Bill had to wait, the angrier he got</em> is an instance of the comparative conditional relation and construction: a degree of length of time that Bill had to wait can (in a <a href="#generic-conditional-relation-(sem)">generic conditional</a>) or does (in an ordinary, specific <a href="#conditional-relation-(sem)">conditional</a>) cause the occurrence of the corresponding degree of Bill's anger. (Section 17.4.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="comparative-conditional-relation-(sem)">
 <h2 class="name"><a href="#comparative-conditional-relation-(sem)">comparative conditional relation (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#comparative-conditional-relation-(sem)-construction-(cxn)">comparative conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#comparative-conditional-construction-(cxn)">comparative conditional construction (<i>cxn</i>)</a></span><span><strong>comparative conditional relation (<i>sem</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">comparative conditional relation</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">comparative conditional relation | comparative conditional</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -3373,27 +2967,14 @@
 <strong>comparative conditional relation (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="comparative-conditional-relation-(sem)-construction-(cxn)">
-<h2 class="name"><a href="#comparative-conditional-relation-(sem)-construction-(cxn)">comparative conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>comparative conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#comparative-conditional-construction-(cxn)">comparative conditional construction (<i>cxn</i>)</a></span><span><a href="#comparative-conditional-relation-(sem)">comparative conditional relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">comparative conditional relation/construction | comparative conditional</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a relation between two events, each on a <a href="#gradable-predicative-scale-(sem)">gradable predicative scale</a>, such that an event at one degree on the first predicative scale causes an event at the corresponding degree on the second predicative scale. <em>Example</em>: <em>The longer that Bill had to wait, the angrier he got</em> is an instance of the comparative conditional relation and construction: a degree of length of time that Bill had to wait can (in a <a href="#generic-conditional-relation-(sem)-construction-(cxn)">generic conditional</a>) or does (in an ordinary, specific <a href="#conditional-relation-(sem)-construction-(cxn)">conditional</a>) cause the occurrence of the corresponding degree of Bill's anger. (Section 17.4.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a relation between two events, each on a <a href="#gradable-predicative-scale-(sem)">gradable predicative scale</a>, such that an event at one degree on the first predicative scale causes an event at the corresponding degree on the second predicative scale. <em>Example</em>: <em>The longer that Bill had to wait, the angrier he got</em> is an instance of the comparative conditional relation and construction: a degree of length of time that Bill had to wait can (in a <a href="#generic-conditional-relation-(sem)">generic conditional</a>) or does (in an ordinary, specific <a href="#conditional-relation-(sem)">conditional</a>) cause the occurrence of the corresponding degree of Bill's anger. (Section 17.4.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="comparative-construction-(cxn)">
 <h2 class="name"><a href="#comparative-construction-(cxn)">comparative construction (<i>cxn</i>)</a></h2>
 <table>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">comparative construction</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">comparative construction | comparative</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -3444,6 +3025,7 @@
 <strong>comparative pronoun (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#pronoun-(cxn)">pronoun</a> expressing a <a href="#comparative-referent-(inf)">comparative referent</a>. <em>Example</em>: in <em>The boy runs as fast as anyone in his class</em>, <em>anyone</em> is a comparative pronoun expressing a hypothetical referent selected from the class representing the standard to which the boy's running is being compared. (Section 3.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="comparative-referent-(inf)">
@@ -3466,19 +3048,6 @@
 <strong>comparative referent (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="comparative-referent-(inf)-pronoun-(cxn)">
-<h2 class="name"><a href="#comparative-referent-(inf)-pronoun-(cxn)">comparative referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>comparative referent (<i>inf</i>) / pronoun (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#comparative-pronoun-(cxn)">comparative pronoun (<i>cxn</i>)</a></span><span><a href="#comparative-referent-(inf)">comparative referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">comparative referent/pronoun | comparative</td></tr>
 <tr><th>Definition</th> <td class="ccinfo definition">an unspecified <a href="#reference,-referent-(inf)">referent</a> occurring in the <a href="#standard-(sem)">standard</a> of comparison in a <a href="#comparative-construction-(cxn)">comparative construction</a>. <em>Example</em>: in <em>The boy runs as fast as anyone in his class</em>, <em>anyone</em> is a comparative pronoun expressing a hypothetical referent selected from the class representing the standard to which the boy's running is being compared. (Section 3.5)</td></tr>
 </table>
 </div>
@@ -3801,12 +3370,6 @@
 <div class="cc" id="concessive-conditional-construction-(cxn)">
 <h2 class="name"><a href="#concessive-conditional-construction-(cxn)">concessive conditional construction (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#concessive-conditional-relation-(sem)-construction-(cxn)">concessive conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>concessive conditional construction (<i>cxn</i>)</strong></span><span><a href="#concessive-conditional-relation-(sem)">concessive conditional relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">concessive conditional construction | conditional concessive construction</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -3823,19 +3386,14 @@
 <span><a href="#speech-act-causal-construction-(cxn)">speech act causal construction (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the construction that expresses a <a href="#concessive-conditional-relation-(sem)">concessive conditional relation</a>. <em>Example</em>: <em>However much advice you give him, he does exactly what he wants to do</em> is an instance of the concessive conditional relation and construction – the <a href="#protasis-(sem)">protasis</a> <em>However much advice you give him</em> introduces a scalar model of your giving him a full range of amounts of advice; and the <a href="#apodosis-(sem)">apodosis</a> <em>he does exactly what he wants to do</em> describes the event that occurs or would occur under any of those conditions. The speaker has a neutral epistemic stance toward the range of events associated with the scalar model. The apodosis has an unexpected causal relation with respect to the set of events that make up the protasis. A concessive conditional may express a <a href="#content-causal-relation-(sem)">content</a>, <a href="#epistemic-causal-relation-(sem)">epistemic</a>, or <a href="#speech-act-causal-relation-(sem)">speech act causal relation</a>. (Section 17.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="concessive-conditional-relation-(sem)">
 <h2 class="name"><a href="#concessive-conditional-relation-(sem)">concessive conditional relation (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#concessive-conditional-relation-(sem)-construction-(cxn)">concessive conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#concessive-conditional-construction-(cxn)">concessive conditional construction (<i>cxn</i>)</a></span><span><strong>concessive conditional relation (<i>sem</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">concessive conditional relation | conditional concessive relation</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">concessive conditional relation | conditional concessive relation | concessive conditional</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#neutral-epistemic-stance-(sem)">neutral epistemic stance (<i>sem</i>)</a> | <a href="#concessive-relation-(sem)">concessive relation (<i>sem</i>)</a> | <a href="#conditional-relation-(sem)">conditional relation (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -3846,31 +3404,12 @@
 <strong>concessive conditional relation (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="concessive-conditional-relation-(sem)-construction-(cxn)">
-<h2 class="name"><a href="#concessive-conditional-relation-(sem)-construction-(cxn)">concessive conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>concessive conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#concessive-conditional-construction-(cxn)">concessive conditional construction (<i>cxn</i>)</a></span><span><a href="#concessive-conditional-relation-(sem)">concessive conditional relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">concessive conditional relation/construction | concessive conditional | conditional concessive</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#causal-(sem)">causal relation</a> between a set of <a href="#event-(sem)">events</a> that are associated with a <a href="#scalar-model-(sem)">scalar model</a> on the one hand, and another event, such that the other event would occur under the entire range of conditions described in the scalar model associated with the first set of events; and the construction that expresses that relation. <em>Example</em>: <em>However much advice you give him, he does exactly what he wants to do</em> is an instance of the concessive conditional relation and construction – the <a href="#protasis-(sem)">protasis</a> <em>However much advice you give him</em> introduces a scalar model of your giving him a full range of amounts of advice; and the <a href="#apodosis-(sem)">apodosis</a> <em>he does exactly what he wants to do</em> describes the event that occurs or would occur under any of those conditions. The speaker has a neutral epistemic stance toward the range of events associated with the scalar model. The apodosis has an unexpected causal relation with respect to the set of events that make up the protasis. A concessive conditional may express a <a href="#content-causal-relation-(sem)">content</a>, <a href="#epistemic-causal-relation-(sem)">epistemic</a>, or <a href="#speech-act-causal-relation-(sem)">speech act causal relation</a>. (Section 17.3.3)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#causal-(sem)">causal relation</a> between a set of <a href="#event-(sem)">events</a> that are associated with a <a href="#scalar-model-(sem)">scalar model</a> on the one hand, and another event, such that the other event would occur under the entire range of conditions described in the scalar model associated with the first set of events. <em>Example</em>: <em>However much advice you give him, he does exactly what he wants to do</em> is an instance of the concessive conditional relation and construction – the <a href="#protasis-(sem)">protasis</a> <em>However much advice you give him</em> introduces a scalar model of your giving him a full range of amounts of advice; and the <a href="#apodosis-(sem)">apodosis</a> <em>he does exactly what he wants to do</em> describes the event that occurs or would occur under any of those conditions. The speaker has a neutral epistemic stance toward the range of events associated with the scalar model. The apodosis has an unexpected causal relation with respect to the set of events that make up the protasis. A concessive conditional may express a <a href="#content-causal-relation-(sem)">content</a>, <a href="#epistemic-causal-relation-(sem)">epistemic</a>, or <a href="#speech-act-causal-relation-(sem)">speech act causal relation</a>. (Section 17.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="concessive-construction-(cxn)">
 <h2 class="name"><a href="#concessive-construction-(cxn)">concessive construction (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#concessive-relation-(sem)-construction-(cxn)">concessive relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>concessive construction (<i>cxn</i>)</strong></span><span><a href="#concessive-relation-(sem)">concessive relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">concessive construction</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#adversative-coordination-(cxn)">adversative coordination (<i>cxn</i>)</a></td></tr>
@@ -3888,19 +3427,14 @@
 <span><a href="#speech-act-causal-construction-(cxn)">speech act causal construction (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the construction that expresses a <a href="#concessive-relation-(sem)">concessive relation</a>.. <em>Example</em>: <em>Although it was raining, I went out</em> is an instance of a concessive relation and construction: the expected causal relation is that rain would lead to my staying in; but in fact I went out. The speaker has a <a href="#positive-epistemic-stance-(sem)">positive epistemic stance</a> toward the concessive construction. A concessive may express a <a href="#content-causal-relation-(sem)">content</a>, <a href="#epistemic-causal-relation-(sem)">epistemic</a>, or <a href="#speech-act-causal-relation-(sem)">speech act causal relation</a>. (Section 17.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="concessive-relation-(sem)">
 <h2 class="name"><a href="#concessive-relation-(sem)">concessive relation (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#concessive-relation-(sem)-construction-(cxn)">concessive relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#concessive-construction-(cxn)">concessive construction (<i>cxn</i>)</a></span><span><strong>concessive relation (<i>sem</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">concessive relation</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">concessive relation | concessive</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#positive-epistemic-stance-(sem)">positive epistemic stance (<i>sem</i>)</a> | <a href="#unexpected-co-occurrence-(sem)">unexpected co-occurrence (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -3911,19 +3445,6 @@
 <strong>concessive relation (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="concessive-relation-(sem)-construction-(cxn)">
-<h2 class="name"><a href="#concessive-relation-(sem)-construction-(cxn)">concessive relation (<i>sem</i>) / construction (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>concessive relation (<i>sem</i>) / construction (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#concessive-construction-(cxn)">concessive construction (<i>cxn</i>)</a></span><span><a href="#concessive-relation-(sem)">concessive relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">concessive relation/construction | concessive</td></tr>
 <tr><th>Definition</th> <td class="ccinfo definition">a relation between two <a href="#event-(sem)">events</a> such that there is an expected <a href="#causal-(sem)">causal relation</a> between the two events, but the opposite of the second event, expressed in the <a href="#apodosis-(sem)">apodosis</a>, unexpectedly occurs. <em>Example</em>: <em>Although it was raining, I went out</em> is an instance of a concessive relation and construction: the expected causal relation is that rain would lead to my staying in; but in fact I went out. The speaker has a <a href="#positive-epistemic-stance-(sem)">positive epistemic stance</a> toward the concessive construction. A concessive may express a <a href="#content-causal-relation-(sem)">content</a>, <a href="#epistemic-causal-relation-(sem)">epistemic</a>, or <a href="#speech-act-causal-relation-(sem)">speech act causal relation</a>. (Section 17.3.2)</td></tr>
 </table>
 </div>
@@ -3947,12 +3468,6 @@
 <div class="cc" id="conditional-construction-(cxn)">
 <h2 class="name"><a href="#conditional-construction-(cxn)">conditional construction (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#conditional-relation-(sem)-construction-(cxn)">conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>conditional construction (<i>cxn</i>)</strong></span><span><a href="#conditional-relation-(sem)">conditional relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">conditional construction</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -3970,6 +3485,7 @@
 <span><a href="#speech-act-causal-construction-(cxn)">speech act causal construction (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> that expresses a <a href="#conditional-relation-(sem)">conditional relation</a>. <em>Example</em>: <em>If you press this button, the door will open</em> is an instance of the conditional relation and construction. The causally antecedent proposition is the <a href="#protasis-(sem)">protasis</a>, and the causally consequent proposition is the <a href="#apodosis-(sem)">apodosis</a>. A conditional may express a <a href="#content-causal-relation-(sem)">content</a>, <a href="#epistemic-causal-relation-(sem)">epistemic</a> or <a href="#speech-act-causal-relation-(sem)">speech act causal relation</a>. (Section 17.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="conditional-deranking-system-(str)">
@@ -4011,12 +3527,6 @@
 <div class="cc" id="conditional-pronoun-(cxn)">
 <h2 class="name"><a href="#conditional-pronoun-(cxn)">conditional pronoun (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#conditional-referent-(inf)-pronoun-(cxn)">conditional referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>conditional pronoun (<i>cxn</i>)</strong></span><span><a href="#conditional-referent-(inf)">conditional referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">conditional pronoun</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -4028,17 +3538,12 @@
 <strong>conditional pronoun (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a conditional pronoun that expresses a <a href="#conditional-referent-(inf)">conditional referent</a>. <em>Example</em>: in <em>If you hear <strong>anything</strong>, tell me</em>, <em>anything</em> is a conditional pronoun expressing a referent that is found only in the hypothetical world introduced by the protasis of the conditional construction. (Section 3.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="conditional-referent-(inf)">
 <h2 class="name"><a href="#conditional-referent-(inf)">conditional referent (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#conditional-referent-(inf)-pronoun-(cxn)">conditional referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#conditional-pronoun-(cxn)">conditional pronoun (<i>cxn</i>)</a></span><span><strong>conditional referent (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">conditional referent</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -4050,33 +3555,14 @@
 <strong>conditional referent (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="conditional-referent-(inf)-pronoun-(cxn)">
-<h2 class="name"><a href="#conditional-referent-(inf)-pronoun-(cxn)">conditional referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>conditional referent (<i>inf</i>) / pronoun (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#conditional-pronoun-(cxn)">conditional pronoun (<i>cxn</i>)</a></span><span><a href="#conditional-referent-(inf)">conditional referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">conditional referent/pronoun | conditional</td></tr>
 <tr><th>Definition</th> <td class="ccinfo definition">an unspecified <a href="#reference,-referent-(inf)">referent</a> in the <a href="#protasis-(sem)">protasis</a> in a <a href="#conditional-construction-(cxn)">conditional construction</a>. <em>Example</em>: in <em>If you hear <strong>anything</strong>, tell me</em>, <em>anything</em> is a conditional pronoun expressing a referent that is found only in the hypothetical world introduced by the protasis of the conditional construction. (Section 3.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="conditional-relation-(sem)">
 <h2 class="name"><a href="#conditional-relation-(sem)">conditional relation (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#conditional-relation-(sem)-construction-(cxn)">conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#conditional-construction-(cxn)">conditional construction (<i>cxn</i>)</a></span><span><strong>conditional relation (<i>sem</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">conditional relation</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">conditional relation | conditional</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -4089,20 +3575,7 @@
 <span><a href="#generic-conditional-relation-(sem)">generic conditional relation (<i>sem</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="conditional-relation-(sem)-construction-(cxn)">
-<h2 class="name"><a href="#conditional-relation-(sem)-construction-(cxn)">conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#conditional-construction-(cxn)">conditional construction (<i>cxn</i>)</a></span><span><a href="#conditional-relation-(sem)">conditional relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">conditional relation/construction | conditional</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a semantic relation between two <a href="#event-(sem)">events</a> that involves a logical material implication relation between their corresponding <a href="#proposition-(sem)">propositions</a>, some type of <a href="#causal-(sem)">causal relation</a> between the corresponding <a href="#event-(sem)">events</a>, and non-positive <a href="#epistemic-stance-(sem)">epistemic stance</a>; and the <a href="#construction-(def)">construction</a> that expresses that relation. <em>Example</em>: <em>If you press this button, the door will open</em> is an instance of the conditional relation and construction. The causally antecedent proposition is the <a href="#protasis-(sem)">protasis</a>, and the causally consequent proposition is the <a href="#apodosis-(sem)">apodosis</a>. A conditional may express a <a href="#content-causal-relation-(sem)">content</a>, <a href="#epistemic-causal-relation-(sem)">epistemic</a> or <a href="#speech-act-causal-relation-(sem)">speech act causal relation</a>. (Section 17.3.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a semantic relation between two <a href="#event-(sem)">events</a> that involves a logical material implication relation between their corresponding <a href="#proposition-(sem)">propositions</a>, some type of <a href="#causal-(sem)">causal relation</a> between the corresponding <a href="#event-(sem)">events</a>, and non-positive <a href="#epistemic-stance-(sem)">epistemic stance</a>. <em>Example</em>: <em>If you press this button, the door will open</em> is an instance of the conditional relation and construction. The causally antecedent proposition is the <a href="#protasis-(sem)">protasis</a>, and the causally consequent proposition is the <a href="#apodosis-(sem)">apodosis</a>. A conditional may express a <a href="#content-causal-relation-(sem)">content</a>, <a href="#epistemic-causal-relation-(sem)">epistemic</a> or <a href="#speech-act-causal-relation-(sem)">speech act causal relation</a>. (Section 17.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="conjoined-comparative-(str)">
@@ -4121,7 +3594,7 @@
 <strong>conjoined comparative (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#derived-case-(str)">derived-case</a> <span class="separation"/> <a href="#comparative-referent-(inf)-pronoun-(cxn)">comparative</a> <span class="separation"/> <a href="#strategy-(def)">strategy</a> which consists of a <a href="#coordinate-clause-construction-(cxn)">coordinate clause construction</a> where the two <a href="#clause-(cxn)">clauses</a> assert that the <a href="#gradable-predicative-scale-(sem)">gradable predicative scale</a> applies to the <a href="#comparee-(sem)">comparee</a> and the <a href="#standard-(sem)">standard</a>. <em>Example</em>: Sika <em>dzarang tica gahar, dzarang rei kesik</em> <q>That horse is bigger than this horse</q> is an instance of the conjoined comparative – it conjoins <em>dzarang tica gahar</em> <q>That horse is big</q> and <em>dzarang rei kesik</em> <q>This horse is small</q>. (Section 17.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#derived-case-(str)">derived-case</a> <span class="separation"/> <a href="#comparative-construction-(cxn)">comparative</a> <span class="separation"/> <a href="#strategy-(def)">strategy</a> which consists of a <a href="#coordinate-clause-construction-(cxn)">coordinate clause construction</a> where the two <a href="#clause-(cxn)">clauses</a> assert that the <a href="#gradable-predicative-scale-(sem)">gradable predicative scale</a> applies to the <a href="#comparee-(sem)">comparee</a> and the <a href="#standard-(sem)">standard</a>. <em>Example</em>: Sika <em>dzarang tica gahar, dzarang rei kesik</em> <q>That horse is bigger than this horse</q> is an instance of the conjoined comparative – it conjoins <em>dzarang tica gahar</em> <q>That horse is big</q> and <em>dzarang rei kesik</em> <q>This horse is small</q>. (Section 17.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="conjoined-exceed-comparative-(str)">
@@ -4240,14 +3713,8 @@
 <div class="cc" id="contact-by-impact-event-(sem)">
 <h2 class="name"><a href="#contact-by-impact-event-(sem)">contact by impact event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#contact-by-impact-event-(sem)-verb-(cxn)">contact by impact event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>contact by impact event (<i>sem</i>)</strong></span><span><a href="#contact-by-impact-verb-(cxn)">contact by impact verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">contact by impact event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">contact by impact event | contact by impact</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -4257,31 +3724,12 @@
 <strong>contact by impact event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="contact-by-impact-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#contact-by-impact-event-(sem)-verb-(cxn)">contact by impact event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>contact by impact event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#contact-by-impact-event-(sem)">contact by impact event (<i>sem</i>)</a></span><span><a href="#contact-by-impact-verb-(cxn)">contact by impact verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">contact by impact event/verb | contact by impact</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> describing contact by impact; and the <a href="#verb-(cxn)">verb</a> expressing such an event. <em>Example</em>: hitting is a contact by impact event, and <em>hit</em> is a contact by impact verb. (Section 7.3.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> describing contact by impact. <em>Example</em>: hitting is a contact by impact event. (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="contact-by-impact-verb-(cxn)">
 <h2 class="name"><a href="#contact-by-impact-verb-(cxn)">contact by impact verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#contact-by-impact-event-(sem)-verb-(cxn)">contact by impact event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#contact-by-impact-event-(sem)">contact by impact event (<i>sem</i>)</a></span><span><strong>contact by impact verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">contact by impact verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -4293,6 +3741,7 @@
 <strong>contact by impact verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing a <a href="#contact-by-impact-event-(sem)">contact by impact event</a>. <em>Example</em>: hitting is a contact by impact event, and <em>hit</em> is a contact by impact verb. (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="container-term-(cxn)">
@@ -4315,12 +3764,6 @@
 <div class="cc" id="content-causal-construction-(cxn)">
 <h2 class="name"><a href="#content-causal-construction-(cxn)">content causal construction (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#content-causal-relation-(sem)-construction-(cxn)">content causal relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>content causal construction (<i>cxn</i>)</strong></span><span><a href="#content-causal-relation-(sem)">content causal relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">content causal construction</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -4335,17 +3778,12 @@
 <strong>content causal construction (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the construction expressing a <a href="#content-causal-relation-(sem)">content causal relation</a>. <em>Example</em>: in <em>If you press this button, the door will open</em>, there is a content causal relation between the event of your pressing the button and the event of the door opening. (Section 17.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="content-causal-relation-(sem)">
 <h2 class="name"><a href="#content-causal-relation-(sem)">content causal relation (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#content-causal-relation-(sem)-construction-(cxn)">content causal relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#content-causal-construction-(cxn)">content causal construction (<i>cxn</i>)</a></span><span><strong>content causal relation (<i>sem</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">content causal relation</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -4357,20 +3795,7 @@
 <strong>content causal relation (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="content-causal-relation-(sem)-construction-(cxn)">
-<h2 class="name"><a href="#content-causal-relation-(sem)-construction-(cxn)">content causal relation (<i>sem</i>) / construction (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>content causal relation (<i>sem</i>) / construction (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#content-causal-construction-(cxn)">content causal construction (<i>cxn</i>)</a></span><span><a href="#content-causal-relation-(sem)">content causal relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">content causal relation/construction | content causal</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the semantic relation in a <a href="#conditional-relation-(sem)-construction-(cxn)">conditional</a>, <a href="#causal-(sem)">causal</a>, <a href="#concessive-relation-(sem)-construction-(cxn)">concessive</a>, or <a href="#concessive-conditional-construction-(cxn)">conditional concessive construction</a> that expresses a <a href="#causal-(sem)">causal relation</a> between events in the world; and the construction expressing that relation. <em>Example</em>: in <em>If you press this button, the door will open</em>, there is a content causal relation between the event of your pressing the button and the event of the door opening. A content causal relation contrasts with an <a href="#epistemic-causal-relation-(sem)">epistemic causal relation</a> or a <a href="#speech-act-causal-relation-(sem)">speech act causal relation</a>. (Section 17.3.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the semantic relation in a <a href="#conditional-relation-(sem)">conditional</a>, <a href="#causal-(sem)">causal</a>, <a href="#concessive-relation-(sem)">concessive</a>, or <a href="#concessive-conditional-construction-(cxn)">conditional concessive construction</a> that expresses a <a href="#causal-(sem)">causal relation</a> between events in the world. <em>Example</em>: in <em>If you press this button, the door will open</em>, there is a content causal relation between the event of your pressing the button and the event of the door opening. A content causal relation contrasts with an <a href="#epistemic-causal-relation-(sem)">epistemic causal relation</a> or a <a href="#speech-act-causal-relation-(sem)">speech act causal relation</a>. (Section 17.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="contextual-(sem)">
@@ -4454,12 +3879,6 @@
 <div class="cc" id="controlled-activity-(sem)">
 <h2 class="name"><a href="#controlled-activity-(sem)">controlled activity (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#controlled-activity-(sem)-predicate-(cxn)">controlled activity (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>controlled activity (<i>sem</i>)</strong></span><span><a href="#controlled-predicate-(cxn)">controlled predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">controlled activity</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -4474,31 +3893,12 @@
 <span><a href="#ingestion-event-(sem)">ingestion event (<i>sem</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="controlled-activity-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#controlled-activity-(sem)-predicate-(cxn)">controlled activity (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>controlled activity (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#controlled-activity-(sem)">controlled activity (<i>sem</i>)</a></span><span><a href="#controlled-predicate-(cxn)">controlled predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">controlled activity/predicate | controlled</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#event-(sem)">event</a> class of agentive processes, and the <a href="#predicate-(cxn)">predicates</a> that express events in this class. <em>Example</em>: running is a controlled activity event, and <em>run</em> is a controlled activity predicate. (Section 6.3.3)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#event-(sem)">event</a> class of agentive processes. <em>Example</em>: running is a controlled activity event. (Section 6.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="controlled-predicate-(cxn)">
 <h2 class="name"><a href="#controlled-predicate-(cxn)">controlled predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#controlled-activity-(sem)-predicate-(cxn)">controlled activity (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#controlled-activity-(sem)">controlled activity (<i>sem</i>)</a></span><span><strong>controlled predicate (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">controlled predicate</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -4510,6 +3910,7 @@
 <strong>controlled predicate (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#predicate-(cxn)">predicates</a> that express events in the <a href="#controlled-activity-(sem)">controlled activity</a> class. <em>Example</em>: running is a controlled activity event, and <em>run</em> is a controlled activity predicate. (Section 6.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="controller-(str)">
@@ -4564,7 +3965,7 @@
 <strong>converb strategy (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-event-(sem)-verb-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is packaged as a separate primary <a href="#predication-(inf)">predication</a> <span class="separation"/> <a href="#coordinate-construction-(cxn)">coordinated</a> with the <a href="#event-(sem)">event</a> predication using a <a href="#deranked,-deranking-(str)">deranked</a> <span class="separation"/> <a href="#complex-sentence-(cxn)">complex sentence</a> <span class="separation"/> <a href="#strategy-(def)">strategy</a>. However, the stative predicate does not index (any of) its argument(s). <em>Example</em>: in Turkana <em>è-pès-e-tè nɪ-a-ron-o-nì̥</em> <q>They kick him badly</q> [lit. <q>They kick him, it being bad</q>] the form of <em>nɪ-a-ron-o-nì̥</em> <q>be bad</q> is a Neuter deranked form, not indexing the third person plural subject of <q>kick</q>. (Section 14.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-complex-predicate-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is packaged as a separate primary <a href="#predication-(inf)">predication</a> <span class="separation"/> <a href="#coordinate-construction-(cxn)">coordinated</a> with the <a href="#event-(sem)">event</a> predication using a <a href="#deranked,-deranking-(str)">deranked</a> <span class="separation"/> <a href="#complex-sentence-(cxn)">complex sentence</a> <span class="separation"/> <a href="#strategy-(def)">strategy</a>. However, the stative predicate does not index (any of) its argument(s). <em>Example</em>: in Turkana <em>è-pès-e-tè nɪ-a-ron-o-nì̥</em> <q>They kick him badly</q> [lit. <q>They kick him, it being bad</q>] the form of <em>nɪ-a-ron-o-nì̥</em> <q>be bad</q> is a Neuter deranked form, not indexing the third person plural subject of <q>kick</q>. (Section 14.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="coordinand-(cxn)">
@@ -4644,7 +4045,7 @@
 <strong>coordinate impersonal strategy (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-event-(sem)-verb-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is packaged as a separate primary <a href="#predication-(inf)">predication</a> <span class="separation"/> <a href="#coordinate-construction-(cxn)">coordinated</a> with the <a href="#event-(sem)">event</a> predication using a <a href="#balanced,-balancing-(str)">balanced</a> <span class="separation"/> <a href="#complex-sentence-(cxn)">complex sentence</a> <span class="separation"/> <a href="#strategy-(def)">strategy</a>. However, the stative predicate does not index (any of) its argument(s). <em>Example</em>: in Koasati <em>wayóhka-k ho-palkálki-palámni-n</em> <q>They fly all very fast</q> [lit. <q>They fly (and) it is fast</q>], the second clause <em>ho-palkálki-palámni-n</em> recruits the form of a main clause predicate, but does not index the fliers. (Section 14.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-complex-predicate-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is packaged as a separate primary <a href="#predication-(inf)">predication</a> <span class="separation"/> <a href="#coordinate-construction-(cxn)">coordinated</a> with the <a href="#event-(sem)">event</a> predication using a <a href="#balanced,-balancing-(str)">balanced</a> <span class="separation"/> <a href="#complex-sentence-(cxn)">complex sentence</a> <span class="separation"/> <a href="#strategy-(def)">strategy</a>. However, the stative predicate does not index (any of) its argument(s). <em>Example</em>: in Koasati <em>wayóhka-k ho-palkálki-palámni-n</em> <q>They fly all very fast</q> [lit. <q>They fly (and) it is fast</q>], the second clause <em>ho-palkálki-palámni-n</em> recruits the form of a main clause predicate, but does not index the fliers. (Section 14.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="coordinate-personal-strategy-(str)">
@@ -4663,7 +4064,7 @@
 <strong>coordinate personal strategy (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-event-(sem)-verb-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is packaged as a separate primary <a href="#predication-(inf)">predication</a> <span class="separation"/> <a href="#coordinate-construction-(cxn)">coordinated</a> with the <a href="#event-(sem)">event</a> predication using a <a href="#balanced,-balancing-(str)">balanced</a> <span class="separation"/> <a href="#complex-sentence-(cxn)">complex sentence</a> <span class="separation"/> <a href="#strategy-(def)">strategy</a>. In addition, the stative predicate <a href="#index-(str)">indexes</a> (one of) its argument(s). <em>Example</em>: in Muna <em>ne-rimba no-tende</em> <q>he runs fast</q> [lit. <q>He is fast (and) he runs</q>], <em>ne-rimba</em> [<span class="sc">3sg.rl</span>-be_fast] recruits the form of a simple predicate and indexes its subject argument. (Section 14.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-complex-predicate-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is packaged as a separate primary <a href="#predication-(inf)">predication</a> <span class="separation"/> <a href="#coordinate-construction-(cxn)">coordinated</a> with the <a href="#event-(sem)">event</a> predication using a <a href="#balanced,-balancing-(str)">balanced</a> <span class="separation"/> <a href="#complex-sentence-(cxn)">complex sentence</a> <span class="separation"/> <a href="#strategy-(def)">strategy</a>. In addition, the stative predicate <a href="#index-(str)">indexes</a> (one of) its argument(s). <em>Example</em>: in Muna <em>ne-rimba no-tende</em> <q>he runs fast</q> [lit. <q>He is fast (and) he runs</q>], <em>ne-rimba</em> [<span class="sc">3sg.rl</span>-be_fast] recruits the form of a simple predicate and indexes its subject argument. (Section 14.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="coordinator-(str)">
@@ -4725,7 +4126,7 @@
 <strong>copular participle strategy (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-event-(sem)-verb-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> recruits a <a href="#nonprototypical-predication-(cxn)">nonprototypical predication</a> construction that employs a <a href="#copula-(str)">copula</a>, and in addition the copula is in a <a href="#deranked,-deranking-(str)">deranked</a> form. <em>Example</em>: in Malayalam <em>aval bhamgiy-aayi prasamgiccu</em> <q>She spoke beautifully</q>, <em>bhamgiy</em> <q>beauty</q> is suffixed with a deranked form of the copula <em>-aayi</em>. (Section 14.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-complex-predicate-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> recruits a <a href="#nonprototypical-predication-(cxn)">nonprototypical predication</a> construction that employs a <a href="#copula-(str)">copula</a>, and in addition the copula is in a <a href="#deranked,-deranking-(str)">deranked</a> form. <em>Example</em>: in Malayalam <em>aval bhamgiy-aayi prasamgiccu</em> <q>She spoke beautifully</q>, <em>bhamgiy</em> <q>beauty</q> is suffixed with a deranked form of the copula <em>-aayi</em>. (Section 14.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="core-argument-phrase-(cxn)">
@@ -4850,12 +4251,6 @@
 <div class="cc" id="damage-event-(sem)">
 <h2 class="name"><a href="#damage-event-(sem)">damage event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#damage-event-(sem)-verb-(cxn)">damage event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>damage event (<i>sem</i>)</strong></span><span><a href="#damage-verb-(cxn)">damage verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">damage event</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -4867,31 +4262,12 @@
 <strong>damage event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="damage-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#damage-event-(sem)-verb-(cxn)">damage event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>damage event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#damage-event-(sem)">damage event (<i>sem</i>)</a></span><span><a href="#damage-verb-(cxn)">damage verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">damage event/verb | damage</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> describing material damage to an <a href="#object-phrase-(cxn)">object</a>; and the <a href="#verb-(cxn)">verb</a> expressing such an event. <em>Example</em>: scratching something is a damage event, and <em>scratch</em> is a damage verb. (Section 7.3.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> describing material damage to an <a href="#object-phrase-(cxn)">object</a>. <em>Example</em>: scratching something is a damage event. (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="damage-verb-(cxn)">
 <h2 class="name"><a href="#damage-verb-(cxn)">damage verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#damage-event-(sem)-verb-(cxn)">damage event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#damage-event-(sem)">damage event (<i>sem</i>)</a></span><span><strong>damage verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">damage verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -4904,6 +4280,7 @@
 <strong>damage verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing a <a href="#damage-event-(sem)">damage event</a>. <em>Example</em>: scratching something is a damage event, and <em>scratch</em> is a damage verb. (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="declarative-(cxn)">
@@ -4929,20 +4306,7 @@
 <span><a href="#declarative-negation-construction-(cxn)">declarative negation construction (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="declarative-(inf-cxn)">
-<h2 class="name"><a href="#declarative-(inf-cxn)">declarative (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>declarative (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#declarative-(cxn)">declarative (<i>cxn</i>)</a></span><span><a href="#declarative-(inf)">declarative (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">declarative</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#speech-acts-(inf)">speech act</a> which simply asserts its <a href="#propositional-content-(sem)">propositional content</a>, and the <a href="#construction-(def)">construction</a> that expresses this speech act. <em>Example</em>: The English sentence <em>Sandra picked up the children</em> is an instance of a declarative speech act. The declarative is the most common speech act construction, and is considered the default speech act construction. (Section 12.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> that expresses a <a href="#declarative-(inf)">declarative</a> speech act. <em>Example</em>: The English sentence <em>Sandra picked up the children</em> is an instance of a declarative speech act. The declarative is the most common speech act construction, and is considered the default speech act construction. (Section 12.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="declarative-(inf)">
@@ -4965,6 +4329,7 @@
 <strong>declarative (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#speech-acts-(inf)">speech act</a> which simply asserts its <a href="#propositional-content-(sem)">propositional content</a>. <em>Example</em>: The English sentence <em>Sandra picked up the children</em> is an instance of a declarative speech act. (Section 12.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="declarative-negation-construction-(cxn)">
@@ -4988,12 +4353,6 @@
 <div class="cc" id="definite-article-(cxn)">
 <h2 class="name"><a href="#definite-article-(cxn)">definite article (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#definite-pronoun-article-(cxn)">definite pronoun/article (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>definite article (<i>cxn</i>)</strong></span><span><a href="#definite-pronoun-(cxn)">definite pronoun (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">definite article</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -5005,17 +4364,12 @@
 <strong>definite article (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#article-(cxn)">article</a> that is associated with the top end of the <a href="#information-status-(inf)">information status</a> continuum, where the identity of the <a href="#reference,-referent-(inf)">referent</a> is already known to both speaker and hearer. This includes <a href="#active-(inf)">active</a>, <a href="#semi-active-(inf)">semi-active</a>, <a href="#inactive-(inf)">inactive</a>, and <a href="#inferrable-(inf)">inferrable</a> referents. <em>Example</em>: <em>the bowl</em> is an example of a definite referring phrase with a definite article <em>the</em> combined with a <a href="#common-noun-(cxn)">common noun</a> bowl, used in a context where the individual bowl in question is identifiable by both speaker and hearer. (Table 3.4, Section 3.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="definite-pronoun-(cxn)">
 <h2 class="name"><a href="#definite-pronoun-(cxn)">definite pronoun (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#definite-pronoun-article-(cxn)">definite pronoun/article (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#definite-article-(cxn)">definite article (<i>cxn</i>)</a></span><span><strong>definite pronoun (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">definite pronoun</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -5027,20 +4381,7 @@
 <strong>definite pronoun (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="definite-pronoun-article-(cxn)">
-<h2 class="name"><a href="#definite-pronoun-article-(cxn)">definite pronoun/article (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>definite pronoun/article (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#definite-article-(cxn)">definite article (<i>cxn</i>)</a></span><span><a href="#definite-pronoun-(cxn)">definite pronoun (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">definite pronoun/article</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">this term is applied to <a href="#referring-phrase-(cxn)">referring phrases</a> – <a href="#pronoun-(cxn)">pronouns</a> and <a href="#article-(cxn)">articles</a> combined with <a href="#noun-(cxn)">nouns</a> – that are associated with the top end of the <a href="#information-status-(inf)">information status</a> continuum, where the identity of the referent is already known to both speaker and hearer. This includes <a href="#active-(inf)">active</a>, <a href="#semi-active-(inf)">semi-active</a>, <a href="#inactive-(inf)">inactive</a>, and <a href="#inferrable-(inf)">inferrable</a> referents. <em>Example</em>: <em>the glass bowl</em> is an example of a definite referring phrase, used in a context where the individual glass bowl in question is identifiable by both speaker and hearer (Table 3.4, Section 3.3.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#pronoun-(cxn)">pronoun</a> that is associated with the top end of the <a href="#information-status-(inf)">information status</a> continuum, where the identity of the <a href="#reference,-referent-(inf)">referent</a> is already known to both speaker and hearer. This includes <a href="#active-(inf)">active</a>, <a href="#semi-active-(inf)">semi-active</a>, <a href="#inactive-(inf)">inactive</a>, and <a href="#inferrable-(inf)">inferrable</a> referents. <em>Example</em>: in <em>It is under the bed</em>, <em>it</em> is an example of a definite pronoun, used in a context where the referent of it is identifiable by both speaker and hearer. (Table 3.4, Section 3.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="degree-(sem)">
@@ -5221,7 +4562,7 @@
 <strong>departure (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the initial phase of the <a href="#path-of-motion-event-(sem)-verb-(cxn)">path</a> in a <a href="#motion-event-(sem)">motion event</a>. <em>Example</em>: in <em>He went from the tree to the house</em>, the path oblique phrase <em>from the tree</em> denotes the departure phase of the motion event. (Section 14.4)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the initial phase of the <a href="#path-of-motion-event-(sem)">path</a> in a <a href="#motion-event-(sem)">motion event</a>. <em>Example</em>: in <em>He went from the tree to the house</em>, the path oblique phrase <em>from the tree</em> denotes the departure phase of the motion event. (Section 14.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="dependent-(cxn)">
@@ -5374,20 +4715,14 @@
 <span><a href="#relative-based-equative-(str)">relative-based equative (<i>str</i>)</a></span>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a set of strategies found in <a href="#comparative-referent-(inf)-pronoun-(cxn)">comparative</a> and <a href="#equative-construction-(cxn)">equative constructions</a> in which the <a href="#flag,-flagging-(str)">flagging</a> of the <a href="#standard-(sem)">standard</a> is derived from the flagging of the <a href="#comparee-(sem)">comparee</a>. <em>Example</em>: <em>I love you more than him</em> uses a derived-case strategy – the referring phrase referring to the standard, <em>him</em>, uses the Object flag because the referring phrase referring to the comparee, <em>you</em>, is in the Object case. Derived-case strategies include the <a href="#conjoined-comparative-(str)">conjoined comparative strategy</a>, the <a href="#particle-comparative-(str)">particle comparative</a> and <a href="#particle-equative-(str)">equative</a> <span class="separation"/> <a href="#strategy-(def)">strategies</a>, the <a href="#conjoined-exceed-comparative-(str)">conjoined exceed comparative strategy</a>, the <a href="#relative-based-equative-(str)">relative-based equative strategy</a>, and the <a href="#relative-equal-equative-(str)">relative equal equative strategy</a>. (Section 17.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a set of strategies found in <a href="#comparative-construction-(cxn)">comparative</a> and <a href="#equative-construction-(cxn)">equative constructions</a> in which the <a href="#flag,-flagging-(str)">flagging</a> of the <a href="#standard-(sem)">standard</a> is derived from the flagging of the <a href="#comparee-(sem)">comparee</a>. <em>Example</em>: <em>I love you more than him</em> uses a derived-case strategy – the referring phrase referring to the standard, <em>him</em>, uses the Object flag because the referring phrase referring to the comparee, <em>you</em>, is in the Object case. Derived-case strategies include the <a href="#conjoined-comparative-(str)">conjoined comparative strategy</a>, the <a href="#particle-comparative-(str)">particle comparative</a> and <a href="#particle-equative-(str)">equative</a> <span class="separation"/> <a href="#strategy-(def)">strategies</a>, the <a href="#conjoined-exceed-comparative-(str)">conjoined exceed comparative strategy</a>, the <a href="#relative-based-equative-(str)">relative-based equative strategy</a>, and the <a href="#relative-equal-equative-(str)">relative equal equative strategy</a>. (Section 17.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="desiderative-event-(sem)">
 <h2 class="name"><a href="#desiderative-event-(sem)">desiderative event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#desiderative-event-(sem)-predicate-(cxn)">desiderative event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>desiderative event (<i>sem</i>)</strong></span><span><a href="#desiderative-predicate-(cxn)">desiderative predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">desiderative event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">desiderative event | desiderative</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#dependent-time-reference-(sem)">dependent time reference (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -5398,31 +4733,12 @@
 <strong>desiderative event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="desiderative-event-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#desiderative-event-(sem)-predicate-(cxn)">desiderative event (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>desiderative event (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#desiderative-event-(sem)">desiderative event (<i>sem</i>)</a></span><span><a href="#desiderative-predicate-(cxn)">desiderative predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">desiderative event/predicate | desiderative</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> that expresses a desire toward the realization of a future event that is expressed by the complement; and the <a href="#predicate-(cxn)">predicate</a> that expresses the event. <em>Example</em>: in <em>Meagan wants to climb Mt. Baldy on Saturday, wants</em> denotes a desiderative event. Noonan (2007:135) includes intending events in the category of desiderative events. (Section 18.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> that expresses a desire toward the realization of a future event that is expressed by the complement. <em>Example</em>: in <em>Meagan wants to climb Mt. Baldy on Saturday, wants</em> denotes a desiderative event. Noonan (2007:135) includes intending events in the category of desiderative events. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="desiderative-predicate-(cxn)">
 <h2 class="name"><a href="#desiderative-predicate-(cxn)">desiderative predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#desiderative-event-(sem)-predicate-(cxn)">desiderative event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#desiderative-event-(sem)">desiderative event (<i>sem</i>)</a></span><span><strong>desiderative predicate (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">desiderative predicate</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -5434,6 +4750,7 @@
 <strong>desiderative predicate (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#predicate-(cxn)">predicate</a> that expresses a <a href="#desiderative-event-(sem)">desiderative event</a>. <em>Example</em>: in <em>Meagan wants to climb Mt. Baldy on Saturday, wants</em> denotes a desiderative event. Noonan (2007:135) includes intending events in the category of desiderative events. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="detached-topic-phrase-(str)">
@@ -5549,12 +4866,6 @@
 <div class="cc" id="direct-negation-pronoun-(cxn)">
 <h2 class="name"><a href="#direct-negation-pronoun-(cxn)">direct negation pronoun (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#direct-negation-referent-(inf)-pronoun-(cxn)">direct negation referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>direct negation pronoun (<i>cxn</i>)</strong></span><span><a href="#direct-negation-referent-(inf)">direct negation referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">direct negation pronoun</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -5566,17 +4877,12 @@
 <strong>direct negation pronoun (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#pronoun-(cxn)">pronoun</a> that expresses a <a href="#direct-negation-referent-(inf)">direct negation referent</a>. <em>Example</em>: in <em>I noticed nothing</em>, <em>nothing</em> is a direct negation pronoun expressing a referent found only in the negative alternative world to the real world. (Section 3.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="direct-negation-referent-(inf)">
 <h2 class="name"><a href="#direct-negation-referent-(inf)">direct negation referent (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#direct-negation-referent-(inf)-pronoun-(cxn)">direct negation referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#direct-negation-pronoun-(cxn)">direct negation pronoun (<i>cxn</i>)</a></span><span><strong>direct negation referent (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">direct negation referent</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -5588,19 +4894,6 @@
 <strong>direct negation referent (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="direct-negation-referent-(inf)-pronoun-(cxn)">
-<h2 class="name"><a href="#direct-negation-referent-(inf)-pronoun-(cxn)">direct negation referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>direct negation referent (<i>inf</i>) / pronoun (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#direct-negation-pronoun-(cxn)">direct negation pronoun (<i>cxn</i>)</a></span><span><a href="#direct-negation-referent-(inf)">direct negation referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">direct negation referent/pronoun | direct negation</td></tr>
 <tr><th>Definition</th> <td class="ccinfo definition">an unspecified <a href="#reference,-referent-(inf)">referent</a> which is in the scope of <a href="#negation-construction-(cxn)">negation</a> in the same <a href="#clause-(cxn)">clause</a>. <em>Example</em>: in <em>I noticed nothing</em>, <em>nothing</em> is a direct negation pronoun expressing a referent found only in the negative alternative world to the real world. (Section 3.5)</td></tr>
 </table>
 </div>
@@ -5861,7 +5154,7 @@
 <strong>double expression (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> for the expression of <a href="#motion-event-(sem)">motion events</a> in which the <a href="#path-of-motion-event-(sem)-verb-(cxn)">path of motion</a> is expressed as (at least) part of the <a href="#predicate-(cxn)">predicate</a> and also as a <a href="#satellite-(str)">satellite</a>. <em>Example</em>: in Russian <em>Ja vy-bežal iz doma</em> <q>I ran out of the house</q>, the path of going out of the house is expressed both as part of the <a href="#verb-(cxn)">verb</a> (the prefix <em>vy-</em> in <em>vy-bežal</em>) and as the <a href="#flag,-flagging-(str)">flag</a> <em>iz</em>. (Section 14.5)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> for the expression of <a href="#motion-event-(sem)">motion events</a> in which the <a href="#path-of-motion-event-(sem)">path of motion</a> is expressed as (at least) part of the <a href="#predicate-(cxn)">predicate</a> and also as a <a href="#satellite-(str)">satellite</a>. <em>Example</em>: in Russian <em>Ja vy-bežal iz doma</em> <q>I ran out of the house</q>, the path of going out of the house is expressed both as part of the <a href="#verb-(cxn)">verb</a> (the prefix <em>vy-</em> in <em>vy-bežal</em>) and as the <a href="#flag,-flagging-(str)">flag</a> <em>iz</em>. (Section 14.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="double-negation-strategy-(str)">
@@ -5971,7 +5264,7 @@
 <span><a href="#specialized-dual-role-strategy-(str)">specialized dual role strategy (<i>str</i>)</a></span>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#strategy-(def)">strategy</a> of construing the <u>affected</u> <a href="#subject-phrase-(cxn)">subject</a> <span class="separation"/> <a href="#participant-(sem)">participant</a> as playing two distinct <a href="#role-(def)">roles</a> in a <a href="#reflexive-event-(sem)-construction-(cxn)">reflexive</a> or <a href="#reciprocal-event-(sem)">reciprocal event</a>; hence, it is expressed by two distinct <a href="#argument-phrase-(cxn)">argument phrases</a> in a <a href="#reflexive-construction-(cxn)">reflexive construction</a> or a <a href="#reciprocal-construction-(cxn)">reciprocal construction</a>. <em>Examples</em>: the Sa verb form <em>ir-ben-ir</em> [<span class="sc">3du</span>-shoot-<span class="sc">3du</span>] <q>They shoot them / they shoot themselves / they shoot each other</q> construes the plural participants as playing distinct roles, and thereby uses the transitive construction (<q>They shoot them</q>) to express either a reflexive event (<q>They shoot themselves</q>) or a reciprocal event (<q>They shoot each other</q>). (Section 7.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#strategy-(def)">strategy</a> of construing the <u>affected</u> <a href="#subject-phrase-(cxn)">subject</a> <span class="separation"/> <a href="#participant-(sem)">participant</a> as playing two distinct <a href="#role-(def)">roles</a> in a <a href="#reflexive-event-(sem)">reflexive</a> or <a href="#reciprocal-event-(sem)">reciprocal event</a>; hence, it is expressed by two distinct <a href="#argument-phrase-(cxn)">argument phrases</a> in a <a href="#reflexive-construction-(cxn)">reflexive construction</a> or a <a href="#reciprocal-construction-(cxn)">reciprocal construction</a>. <em>Examples</em>: the Sa verb form <em>ir-ben-ir</em> [<span class="sc">3du</span>-shoot-<span class="sc">3du</span>] <q>They shoot them / they shoot themselves / they shoot each other</q> construes the plural participants as playing distinct roles, and thereby uses the transitive construction (<q>They shoot them</q>) to express either a reflexive event (<q>They shoot themselves</q>) or a reciprocal event (<q>They shoot each other</q>). (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="durative-(sem)">
@@ -6079,12 +5372,6 @@
 <div class="cc" id="emotion-event-(sem)">
 <h2 class="name"><a href="#emotion-event-(sem)">emotion event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#emotion-event-(sem)-verb-(cxn)">emotion event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>emotion event (<i>sem</i>)</strong></span><span><a href="#emotion-verb-(cxn)">emotion verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">emotion event</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -6096,31 +5383,12 @@
 <strong>emotion event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="emotion-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#emotion-event-(sem)-verb-(cxn)">emotion event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>emotion event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#emotion-event-(sem)">emotion event (<i>sem</i>)</a></span><span><a href="#emotion-verb-(cxn)">emotion verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">emotion event/verb | emotion</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#experiential-event-(sem)">experiential event</a> involving an <a href="#experiencer-(sem)">experiencer</a>'s emotions directed toward a <a href="#stimulus-(sem)">stimulus</a>; and a <a href="#verb-(cxn)">verb</a> that expresses such an event. <em>Example</em>: <em>He fears dogs</em> is an example of an emotion event, and <em>fear</em> is the emotion verb. (Section 7.4)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#experiential-event-(sem)">experiential event</a> involving an <a href="#experiencer-(sem)">experiencer</a>'s emotions directed toward a <a href="#stimulus-(sem)">stimulus</a>. <em>Example</em>: <em>He fears dogs</em> is an example of an emotion event. (Section 7.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="emotion-verb-(cxn)">
 <h2 class="name"><a href="#emotion-verb-(cxn)">emotion verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#emotion-event-(sem)-verb-(cxn)">emotion event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#emotion-event-(sem)">emotion event (<i>sem</i>)</a></span><span><strong>emotion verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">emotion verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -6132,6 +5400,7 @@
 <strong>emotion verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#verb-(cxn)">verb</a> that expresses an <a href="#emotion-event-(sem)">emotion event</a>. <em>Example</em>: <em>He fears dogs</em> is an example of an emotion event, and <em>fear</em> is the emotion verb. (Section 7.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="encoding-strategy-(str)">
@@ -6197,12 +5466,6 @@
 <div class="cc" id="entity-central-(cxn)">
 <h2 class="name"><a href="#entity-central-(cxn)">entity-central (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#entity-central-(inf-cxn)">entity-central (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>entity-central (<i>cxn</i>)</strong></span><span><a href="#entity-central-(inf)">entity-central (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">entity-central</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -6217,31 +5480,12 @@
 <span><a href="#presentational-(cxn)">presentational (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="entity-central-(inf-cxn)">
-<h2 class="name"><a href="#entity-central-(inf-cxn)">entity-central (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>entity-central (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#entity-central-(cxn)">entity-central (<i>cxn</i>)</a></span><span><a href="#entity-central-(inf)">entity-central (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">entity-central</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a type of <a href="#thetic-(inf)">thetic</a> in which the most important new information being presented is the identity of the <a href="#object-phrase-(cxn)">object</a> (entity); and the <a href="#construction-(def)">construction</a> that expresses that information packaging. <em>Example</em>: <em>There's a snake in the kitchen sink</em> is an instance of an entity-central thetic construction, where the primary new information being presented is the snake. (Sections 10.1.2, <strong>11.3.1</strong>)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> that expresses an <a href="#entity-central-(inf)">entity-central</a> information packaging. <em>Example</em>: <em>There's a snake in the kitchen sink</em> is an instance of an entity-central thetic construction, where the primary new information being presented is the snake. (Sections 10.1.2, <strong>11.3.1</strong>)</td></tr>
 </table>
 </div>
 <div class="cc" id="entity-central-(inf)">
 <h2 class="name"><a href="#entity-central-(inf)">entity-central (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#entity-central-(inf-cxn)">entity-central (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#entity-central-(cxn)">entity-central (<i>cxn</i>)</a></span><span><strong>entity-central (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">entity-central</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -6256,17 +5500,12 @@
 <span><a href="#presentational-(inf)">presentational (<i>inf</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a type of <a href="#thetic-(inf)">thetic</a> in which the most important new information being presented is the identity of the <a href="#object-phrase-(cxn)">object</a> (entity). <em>Example</em>: <em>There's a snake in the kitchen sink</em> is an instance of an entity-central thetic construction, where the primary new information being presented is the snake. (Sections 10.1.2, <strong>11.3.1</strong>)</td></tr>
 </table>
 </div>
 <div class="cc" id="epistemic-causal-construction-(cxn)">
 <h2 class="name"><a href="#epistemic-causal-construction-(cxn)">epistemic causal construction (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#epistemic-causal-relation-(sem)-construction-(cxn)">epistemic causal relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>epistemic causal construction (<i>cxn</i>)</strong></span><span><a href="#epistemic-causal-relation-(sem)">epistemic causal relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">epistemic causal construction</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -6281,17 +5520,12 @@
 <strong>epistemic causal construction (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the construction expressing an <a href="#epistemic-causal-relation-(sem)">epistemic causal relation</a>. <em>Example</em>: in <em>If Professor Smith's door is closed, then she is not on campus</em>, there is an epistemic causal relation between the fact that Professor Smith's office door is closed and the inference that she is not on campus. (Section 17.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="epistemic-causal-relation-(sem)">
 <h2 class="name"><a href="#epistemic-causal-relation-(sem)">epistemic causal relation (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#epistemic-causal-relation-(sem)-construction-(cxn)">epistemic causal relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#epistemic-causal-construction-(cxn)">epistemic causal construction (<i>cxn</i>)</a></span><span><strong>epistemic causal relation (<i>sem</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">epistemic causal relation</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -6303,20 +5537,7 @@
 <strong>epistemic causal relation (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="epistemic-causal-relation-(sem)-construction-(cxn)">
-<h2 class="name"><a href="#epistemic-causal-relation-(sem)-construction-(cxn)">epistemic causal relation (<i>sem</i>) / construction (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>epistemic causal relation (<i>sem</i>) / construction (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#epistemic-causal-construction-(cxn)">epistemic causal construction (<i>cxn</i>)</a></span><span><a href="#epistemic-causal-relation-(sem)">epistemic causal relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">epistemic causal relation/construction | epistemic causal</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the semantic relation in a <a href="#conditional-relation-(sem)-construction-(cxn)">conditional</a>, <a href="#causal-(sem)">causal</a>, <a href="#concessive-relation-(sem)-construction-(cxn)">concessive</a>, or <a href="#concessive-conditional-construction-(cxn)">conditional concessive construction</a> that expresses an epistemic inferential relation between two propositions; and the construction expressing that relation. <em>Example</em>: in <em>If Professor Smith's door is closed, then she is not on campus</em>, there is an epistemic causal relation between the fact that Professor Smith's office door is closed and the inference that she is not on campus. An epistemic causal relation contrasts with a <a href="#content-causal-relation-(sem)">content causal relation</a> and a <a href="#speech-act-causal-relation-(sem)">speech act causal relation</a>. (Section 17.3.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the semantic relation in a <a href="#conditional-relation-(sem)">conditional</a>, <a href="#causal-(sem)">causal</a>, <a href="#concessive-relation-(sem)">concessive</a>, or <a href="#concessive-conditional-construction-(cxn)">conditional concessive construction</a> that expresses an epistemic inferential relation between two propositions. <em>Example</em>: in <em>If Professor Smith's door is closed, then she is not on campus</em>, there is an epistemic causal relation between the fact that Professor Smith's office door is closed and the inference that she is not on campus. An epistemic causal relation contrasts with a <a href="#content-causal-relation-(sem)">content causal relation</a> and a <a href="#speech-act-causal-relation-(sem)">speech act causal relation</a>. (Section 17.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="epistemic-modality-(sem)">
@@ -6379,12 +5600,6 @@
 <div class="cc" id="equational-(cxn)">
 <h2 class="name"><a href="#equational-(cxn)">equational (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#equational-(inf-cxn)">equational (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>equational (<i>cxn</i>)</strong></span><span><a href="#equational-(inf)">equational (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">equational</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#predicate-nominal-construction-(cxn)">predicate nominal construction (<i>cxn</i>)</a></td></tr>
@@ -6398,31 +5613,12 @@
 <strong>equational (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="equational-(inf-cxn)">
-<h2 class="name"><a href="#equational-(inf-cxn)">equational (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>equational (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#equational-(cxn)">equational (<i>cxn</i>)</a></span><span><a href="#equational-(inf)">equational (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">equational</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a type of <a href="#identificational-(inf)">identificational information packaging</a> in which two <a href="#reference,-referent-(inf)">referents</a> that the hearer assumed were different individuals are asserted to be, in fact, one and the same individual; and the <a href="#construction-(def)">construction</a> that expresses that information packaging. <em>Example</em>: in <em>The Morning Star is the Evening Star</em>, it is asserted that two celestial objects that were once thought to be distinct objects (and given distinct names) are one and the same, namely the planet Venus. (Section 10.1.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> that expresses an <a href="#equational-(inf)">equational</a> information packaging. <em>Example</em>: in <em>The Morning Star is the Evening Star</em>, it is asserted that two celestial objects that were once thought to be distinct objects (and given distinct names) are one and the same, namely the planet Venus. (Section 10.1.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="equational-(inf)">
 <h2 class="name"><a href="#equational-(inf)">equational (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#equational-(inf-cxn)">equational (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#equational-(cxn)">equational (<i>cxn</i>)</a></span><span><strong>equational (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">equational</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -6434,6 +5630,7 @@
 <strong>equational (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a type of <a href="#identificational-(inf)">identificational information packaging</a> in which two <a href="#reference,-referent-(inf)">referents</a> that the hearer assumed were different individuals are asserted to be, in fact, one and the same individual. <em>Example</em>: in <em>The Morning Star is the Evening Star</em>, it is asserted that two celestial objects that were once thought to be distinct objects (and given distinct names) are one and the same, namely the planet Venus. (Section 10.1.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="equative-construction-(cxn)">
@@ -6509,14 +5706,8 @@
 <div class="cc" id="evaluative-event-(sem)">
 <h2 class="name"><a href="#evaluative-event-(sem)">evaluative event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#evaluative-event-(sem)-predicate-(cxn)">evaluative event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>evaluative event (<i>sem</i>)</strong></span><span><a href="#evaluative-predicate-(cxn)">evaluative predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">evaluative event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">evaluative event | evaluative</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#independent-time-reference-(sem)">independent time reference (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -6533,31 +5724,12 @@
 <span><a href="#wishing-event-(sem)">wishing event (<i>sem</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="evaluative-event-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#evaluative-event-(sem)-predicate-(cxn)">evaluative event (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>evaluative event (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#evaluative-event-(sem)">evaluative event (<i>sem</i>)</a></span><span><a href="#evaluative-predicate-(cxn)">evaluative predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">evaluative event/predicate | evaluative</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> in which an evaluative judgment is made about the truth of the <a href="#proposition-(sem)">proposition</a> expressed in its <a href="#complement-dependent-clause-(cxn)">complement</a>; and a <a href="#predicate-(cxn)">predicate</a> expressing this event. Evaluative events may assume different <a href="#epistemic-stance-(sem)">epistemic stances</a> toward the proposition expressed in their complement. <a href="#commentative-event-(sem)">Commentative events</a> assume a positive epistemic stance; <a href="#hoping-event-(sem)-predicate-(cxn)">hoping</a> and <a href="#fearing-event-(sem)">fearing events</a> assume a <a href="#neutral-epistemic-stance-(sem)">neutral epistemic stance</a>; and <a href="#wishing-event-(sem)">wishing events</a> assume a <a href="#negative-epistemic-stance-(sem)">negative epistemic stance</a>. (Section 18.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> in which an evaluative judgment is made about the truth of the <a href="#proposition-(sem)">proposition</a> expressed in its <a href="#complement-dependent-clause-(cxn)">complement</a>. Evaluative events may assume different <a href="#epistemic-stance-(sem)">epistemic stances</a> toward the proposition expressed in their complement. <a href="#commentative-event-(sem)">Commentative events</a> assume a positive epistemic stance; <a href="#hoping-event-(sem)">hoping</a> and <a href="#fearing-event-(sem)">fearing events</a> assume a <a href="#neutral-epistemic-stance-(sem)">neutral epistemic stance</a>; and <a href="#wishing-event-(sem)">wishing events</a> assume a <a href="#negative-epistemic-stance-(sem)">negative epistemic stance</a>. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="evaluative-predicate-(cxn)">
 <h2 class="name"><a href="#evaluative-predicate-(cxn)">evaluative predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#evaluative-event-(sem)-predicate-(cxn)">evaluative event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#evaluative-event-(sem)">evaluative event (<i>sem</i>)</a></span><span><strong>evaluative predicate (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">evaluative predicate</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -6575,6 +5747,7 @@
 <span><a href="#wishing-predicate-(cxn)">wishing predicate (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#predicate-(cxn)">predicate</a> expressing an <a href="#evaluative-event-(sem)">evaluative event</a>. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="event-(sem)">
@@ -6592,6 +5765,7 @@
 </td></tr>
 <tr><td class="flex">
 <span><a href="#action-concept-(sem)">action (concept) (<i>sem</i>)</a></span>
+<span><a href="#apodosis-(sem)">apodosis (<i>sem</i>)</a></span>
 <span><a href="#base-event-(sem)">base event (<i>sem</i>)</a></span>
 <span><a href="#body-position-event-(sem)">body position event (<i>sem</i>)</a></span>
 <span><a href="#causal-event-(sem)">causal event (<i>sem</i>)</a></span>
@@ -6616,6 +5790,7 @@
 <span><a href="#noncausal-event-(sem)">noncausal event (<i>sem</i>)</a></span>
 <span><a href="#proposition-(sem)">proposition (<i>sem</i>)</a></span>
 <span><a href="#propositional-attitude-event-(sem)">propositional attitude event (<i>sem</i>)</a></span>
+<span><a href="#protasis-(sem)">protasis (<i>sem</i>)</a></span>
 <span><a href="#pursuit-event-(sem)">pursuit event (<i>sem</i>)</a></span>
 <span><a href="#reciprocal-event-(sem)">reciprocal event (<i>sem</i>)</a></span>
 <span><a href="#reflexive-event-(sem)">reflexive event (<i>sem</i>)</a></span>
@@ -6635,12 +5810,6 @@
 <div class="cc" id="event-central-(cxn)">
 <h2 class="name"><a href="#event-central-(cxn)">event-central (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#event-central-(inf-cxn)">event-central (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>event-central (<i>cxn</i>)</strong></span><span><a href="#event-central-(inf)">event-central (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">event-central</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -6652,31 +5821,12 @@
 <strong>event-central (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="event-central-(inf-cxn)">
-<h2 class="name"><a href="#event-central-(inf-cxn)">event-central (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>event-central (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#event-central-(cxn)">event-central (<i>cxn</i>)</a></span><span><a href="#event-central-(inf)">event-central (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">event-central</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a type of <a href="#thetic-(inf)">thetic</a> in which the more important new information being presented is the <a href="#event-(sem)">event</a> reported; and the <a href="#construction-(def)">construction</a> that expresses that information packaging. <em>Example</em>: in <em>The PHONE's ringing</em>, the most important new information is the ringing of the phone, not the existence of the phone. (Sections 10.1.2, <strong>11.3.1</strong>)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#construction-(def)">construction</a> that expresses an <a href="#event-central-(inf)">event-central</a> information packaging. <em>Example</em>: in <em>The PHONE's ringing</em>, the most important new information is the ringing of the phone, not the existence of the phone. (Sections 10.1.2, <strong>11.3.1</strong>)</td></tr>
 </table>
 </div>
 <div class="cc" id="event-central-(inf)">
 <h2 class="name"><a href="#event-central-(inf)">event-central (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#event-central-(inf-cxn)">event-central (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#event-central-(cxn)">event-central (<i>cxn</i>)</a></span><span><strong>event-central (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">event-central</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -6688,6 +5838,7 @@
 <strong>event-central (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a type of <a href="#thetic-(inf)">thetic</a> in which the more important new information being presented is the <a href="#event-(sem)">event</a> reported. <em>Example</em>: in <em>The PHONE's ringing</em>, the most important new information is the ringing of the phone, not the existence of the phone. (Sections 10.1.2, <strong>11.3.1</strong>)</td></tr>
 </table>
 </div>
 <div class="cc" id="event-oriented-(sem)">
@@ -6768,12 +5919,6 @@
 <div class="cc" id="exclamative-(cxn)">
 <h2 class="name"><a href="#exclamative-(cxn)">exclamative (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#exclamative-(inf-cxn)">exclamative (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>exclamative (<i>cxn</i>)</strong></span><span><a href="#exclamative-(inf)">exclamative (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">exclamative</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -6785,31 +5930,12 @@
 <strong>exclamative (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="exclamative-(inf-cxn)">
-<h2 class="name"><a href="#exclamative-(inf-cxn)">exclamative (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>exclamative (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#exclamative-(cxn)">exclamative (<i>cxn</i>)</a></span><span><a href="#exclamative-(inf)">exclamative (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">exclamative</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#speech-acts-(inf)">speech act</a> which expresses a strong emotional reaction to the <a href="#propositional-content-(sem)">propositional content</a> that it conveys; and the <a href="#construction-(def)">construction</a> that expresses this speech act. More precisely, the exclamative speech act expresses the speaker's surprise toward the <a href="#degree-(sem)">degree</a> of a scalar <a href="#property-concept-(sem)">property</a> contained in the propositional content of the speech act; the rest of the propositional content consists of a <a href="#presupposed-open-proposition-(inf)">presupposed open proposition</a>. <em>Example</em>: <em>What a beautiful house!</em> is an instance of an English exclamative construction. (Sections 12.1, 12.5)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#construction-(def)">construction</a> that expresses an <a href="#exclamative-(inf)">exclamative</a> speech act. <em>Example</em>: <em>What a beautiful house!</em> is an instance of an English exclamative construction. (Sections 12.1, 12.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="exclamative-(inf)">
 <h2 class="name"><a href="#exclamative-(inf)">exclamative (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#exclamative-(inf-cxn)">exclamative (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#exclamative-(cxn)">exclamative (<i>cxn</i>)</a></span><span><strong>exclamative (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">exclamative</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -6821,6 +5947,7 @@
 <strong>exclamative (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#speech-acts-(inf)">speech act</a> which expresses a strong emotional reaction to the <a href="#propositional-content-(sem)">propositional content</a> that it conveys. More precisely, the exclamative speech act expresses the speaker's surprise toward the <a href="#degree-(sem)">degree</a> of a scalar <a href="#property-concept-(sem)">property</a> contained in the propositional content of the speech act; the rest of the propositional content consists of a <a href="#presupposed-open-proposition-(inf)">presupposed open proposition</a>. <em>Example</em>: <em>What a beautiful house!</em> is an instance of an English exclamative construction. (Sections 12.1, 12.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="exclusive-disjunctive-coordination-(cxn)">
@@ -6934,12 +6061,6 @@
 <div class="cc" id="experience-event-(sem)">
 <h2 class="name"><a href="#experience-event-(sem)">experience event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#experience-event-(sem)-verb-(cxn)">experience event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>experience event (<i>sem</i>)</strong></span><span><a href="#experience-verb-(cxn)">experience verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">experience event</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#experiential-verb-(cxn)">experiential verb (<i>cxn</i>)</a></td></tr>
@@ -6952,31 +6073,12 @@
 <strong>experience event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="experience-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#experience-event-(sem)-verb-(cxn)">experience event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>experience event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#experience-event-(sem)">experience event (<i>sem</i>)</a></span><span><a href="#experience-verb-(cxn)">experience verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">experience event/verb | experience</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#experiential-event-(sem)">experiential event</a> which describes the state holding between an <a href="#experiencer-(sem)">experiencer</a> directing her/his attention to a <a href="#stimulus-(sem)">stimulus</a> and the stimulus altering the mental state of the experiencer (or the inception of such a state); and a <a href="#verb-(cxn)">verb</a> that expresses such an event. <em>Example</em>: <em>I saw the dog</em> is an instance of an experience event, and <em>see</em> is an experience verb. (Section 7.4)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#experiential-event-(sem)">experiential event</a> which describes the state holding between an <a href="#experiencer-(sem)">experiencer</a> directing her/his attention to a <a href="#stimulus-(sem)">stimulus</a> and the stimulus altering the mental state of the experiencer (or the inception of such a state). <em>Example</em>: <em>I saw the dog</em> is an instance of an experience event. (Section 7.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="experience-verb-(cxn)">
 <h2 class="name"><a href="#experience-verb-(cxn)">experience verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#experience-event-(sem)-verb-(cxn)">experience event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#experience-event-(sem)">experience event (<i>sem</i>)</a></span><span><strong>experience verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">experience verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -6988,6 +6090,7 @@
 <strong>experience verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#verb-(cxn)">verb</a> that expresses an <a href="#experience-event-(sem)">experience event</a>. <em>Example</em>: <em>I saw the dog</em> is an instance of an experience event, and <em>see</em> is an experience verb. (Section 7.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="experiencer-(sem)">
@@ -7046,12 +6149,6 @@
 <div class="cc" id="experiential-event-(sem)">
 <h2 class="name"><a href="#experiential-event-(sem)">experiential event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#experiential-event-(sem)-verb-(cxn)">experiential event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>experiential event (<i>sem</i>)</strong></span><span><a href="#experiential-verb-(cxn)">experiential verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">experiential event</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -7074,20 +6171,7 @@
 <span><a href="#sensation-event-(sem)">sensation event (<i>sem</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="experiential-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#experiential-event-(sem)-verb-(cxn)">experiential event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>experiential event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#experiential-event-(sem)">experiential event (<i>sem</i>)</a></span><span><a href="#experiential-verb-(cxn)">experiential verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">experiential event/verb | experiential</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> that involves a human internal mental or bodily experience; and a <a href="#verb-(cxn)">verb</a> that expresses such an event. Experiential events include <a href="#perception-event-(sem)">perception events</a>, <a href="#cognition-event-(sem)">cognition events</a>, <a href="#emotion-event-(sem)">emotion events</a>, and <a href="#sensation-event-(sem)">(bodily) sensation events</a>; <a href="#ingestion-event-(sem)">ingestion events</a> also exhibit some semantic similarities to experiential events. (Sections 6.1.2, <strong>7.4</strong>)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> that involves a human internal mental or bodily experience. (Sections 6.1.2, <strong>7.4</strong>)</td></tr>
 </table>
 </div>
 <div class="cc" id="experiential-verb-(cxn)">
@@ -7097,7 +6181,7 @@
 <table><tr><td class="flex"><span>
 <a href="#experiential-event-(sem)-verb-(cxn)">experiential event (<i>sem</i>) / verb (<i>cxn</i>)</a>
 </span></td></tr><tr><td class="flex"><span>
-<a href="#experiential-event-(sem)">experiential event (<i>sem</i>)</a></span><span><strong>experiential verb (<i>cxn</i>)</strong>
+<strong>experiential verb (<i>cxn</i>)</strong>
 </span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">experiential verb</td></tr>
@@ -7120,6 +6204,7 @@
 <span><a href="#sensation-verb-(cxn)">sensation verb (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#verb-(cxn)">verb</a> that expresses an <a href="#experiential-event-(sem)">experiential event</a>. Experiential events include <a href="#perception-event-(sem)">perception events</a>, <a href="#cognition-event-(sem)">cognition events</a>, <a href="#emotion-event-(sem)">emotion events</a>, and <a href="#sensation-event-(sem)">(bodily) sensation events</a>; <a href="#ingestion-event-(sem)">ingestion events</a> also exhibit some semantic similarities to experiential events. (Sections 6.1.2, <strong>7.4</strong>)</td></tr>
 </table>
 </div>
 <div class="cc" id="expertum-(sem)">
@@ -7237,12 +6322,6 @@
 <div class="cc" id="extroverted-event-(sem)">
 <h2 class="name"><a href="#extroverted-event-(sem)">extroverted event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#extroverted-event-(sem)-verb-(cxn)">extroverted event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>extroverted event (<i>sem</i>)</strong></span><span><a href="#extroverted-verb-(cxn)">extroverted verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">extroverted event</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -7254,31 +6333,12 @@
 <strong>extroverted event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="extroverted-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#extroverted-event-(sem)-verb-(cxn)">extroverted event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>extroverted event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#extroverted-event-(sem)">extroverted event (<i>sem</i>)</a></span><span><a href="#extroverted-verb-(cxn)">extroverted verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">extroverted event/verb | extroverted</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an event not normally performed on oneself or on each other; and a <a href="#verb-(cxn)">verb</a> expressing such an event. <em>Examples</em>: seeing something vs. oneself, or loving someone vs. oneself (or even each other), are instances of extroverted events, and <em>see</em> and <em>love</em> are extroverted verbs. (Section 7.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an event not normally performed on oneself or on each other. <em>Examples</em>: seeing something vs. oneself, or loving someone vs. oneself (or even each other), are instances of extroverted events, and <em>see</em> and <em>love</em> are extroverted verbs. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="extroverted-verb-(cxn)">
 <h2 class="name"><a href="#extroverted-verb-(cxn)">extroverted verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#extroverted-event-(sem)-verb-(cxn)">extroverted event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#extroverted-event-(sem)">extroverted event (<i>sem</i>)</a></span><span><strong>extroverted verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">extroverted verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -7290,6 +6350,7 @@
 <strong>extroverted verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#verb-(cxn)">verb</a> expressing an <a href="#extroverted-event-(sem)">extroverted event</a>. <em>Examples</em>: seeing something vs. oneself, or loving someone vs. oneself (or even each other), are instances of extroverted events, and <em>see</em> and <em>love</em> are extroverted verbs. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="factive-event-(sem)">
@@ -7307,7 +6368,7 @@
 <strong>factive event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> in which a <a href="#positive-epistemic-stance-(sem)">positive epistemic stance</a> is taken by the speaker toward a <a href="#proposition-(sem)">proposition</a> denoted by some part of that construction. <em>Example</em>: <em>It is appalling that Donald won the election</em> – an example of a <a href="#commentative-event-(sem)-predicate-(cxn)">commentative</a> <span class="separation"/> <a href="#complement-clause-construction-(cxn)">complement clause construction</a> – is factive in that the speaker takes a positive epistemic stance toward the <a href="#complement-dependent-clause-(cxn)">complement</a> proposition that Donald won the election.</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> in which a <a href="#positive-epistemic-stance-(sem)">positive epistemic stance</a> is taken by the speaker toward a <a href="#proposition-(sem)">proposition</a> denoted by some part of that construction. <em>Example</em>: <em>It is appalling that Donald won the election</em> – an example of a <a href="#commentative-event-(sem)">commentative</a> <span class="separation"/> <a href="#complement-clause-construction-(cxn)">complement clause construction</a> – is factive in that the speaker takes a positive epistemic stance toward the <a href="#complement-dependent-clause-(cxn)">complement</a> proposition that Donald won the election.</td></tr>
 </table>
 </div>
 <div class="cc" id="false-cumulation-(def)">
@@ -7321,12 +6382,6 @@
 <div class="cc" id="fearing-event-(sem)">
 <h2 class="name"><a href="#fearing-event-(sem)">fearing event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#fearing-event-(sem)-predicate-(cxn)">fearing event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>fearing event (<i>sem</i>)</strong></span><span><a href="#fearing-predicate-(cxn)">fearing predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">fearing event</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#neutral-epistemic-stance-(sem)">neutral epistemic stance (<i>sem</i>)</a></td></tr>
@@ -7339,31 +6394,12 @@
 <strong>fearing event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="fearing-event-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#fearing-event-(sem)-predicate-(cxn)">fearing event (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>fearing event (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#fearing-event-(sem)">fearing event (<i>sem</i>)</a></span><span><a href="#fearing-predicate-(cxn)">fearing predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">fearing event/predicate | fearing</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#evaluative-event-(sem)">evaluative event</a> in which a negative evaluative judgment about a <a href="#proposition-(sem)">proposition</a> expressed by the <a href="#complement-dependent-clause-(cxn)">complement</a> of the commentative event is made, and there is a <a href="#neutral-epistemic-stance-(sem)">neutral epistemic stance</a> by the speaker toward the proposition; and the <a href="#predicate-(cxn)">predicate</a> expressing this event. <em>Example</em>: in <em>Jill fears that Donald has won the election</em>, the commentative predicate <em>fears</em> expresses Jill's evaluation of Donald's winning the election, and also presupposes that the speaker does not know whether Donald has won the election. (Section 18.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#evaluative-event-(sem)">evaluative event</a> in which a negative evaluative judgment about a <a href="#proposition-(sem)">proposition</a> expressed by the <a href="#complement-dependent-clause-(cxn)">complement</a> of the commentative event is made, and there is a <a href="#neutral-epistemic-stance-(sem)">neutral epistemic stance</a> by the speaker toward the proposition. <em>Example</em>: in <em>Jill fears that Donald has won the election</em>, the commentative predicate <em>fears</em> expresses Jill's evaluation of Donald's winning the election, and also presupposes that the speaker does not know whether Donald has won the election. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="fearing-predicate-(cxn)">
 <h2 class="name"><a href="#fearing-predicate-(cxn)">fearing predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#fearing-event-(sem)-predicate-(cxn)">fearing event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#fearing-event-(sem)">fearing event (<i>sem</i>)</a></span><span><strong>fearing predicate (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">fearing predicate</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -7375,6 +6411,7 @@
 <strong>fearing predicate (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#predicate-(cxn)">predicate</a> expressing a <a href="#fearing-event-(sem)">fearing event</a>. <em>Example</em>: in <em>Jill fears that Donald has won the election</em>, the commentative predicate <em>fears</em> expresses Jill's evaluation of Donald's winning the election, and also presupposes that the speaker does not know whether Donald has won the election. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="figure-(sem)">
@@ -7505,7 +6542,7 @@
 <span><a href="#separative-comparative-(str)">separative comparative (<i>str</i>)</a></span>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a set of strategies found in <a href="#comparative-referent-(inf)-pronoun-(cxn)">comparative</a> and <a href="#equative-construction-(cxn)">equative constructions</a> in which the <a href="#flag,-flagging-(str)">flag</a> of the <a href="#standard-(sem)">standard</a> is fixed (unchanging). <em>Example</em>: Mundari <em>sadom-ete hati mananga-i</em> <q>The elephant is bigger than the horse</q> is an instance of the fixed-case strategy: <em>sadom-ete</em> <q>horse-from</q> always occurs with the flag <em>-ete</em> <q>from</q>. (Section 17.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a set of strategies found in <a href="#comparative-construction-(cxn)">comparative</a> and <a href="#equative-construction-(cxn)">equative constructions</a> in which the <a href="#flag,-flagging-(str)">flag</a> of the <a href="#standard-(sem)">standard</a> is fixed (unchanging). <em>Example</em>: Mundari <em>sadom-ete hati mananga-i</em> <q>The elephant is bigger than the horse</q> is an instance of the fixed-case strategy: <em>sadom-ete</em> <q>horse-from</q> always occurs with the flag <em>-ete</em> <q>from</q>. (Section 17.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="flag,-flagging-(str)">
@@ -7637,12 +6674,6 @@
 <div class="cc" id="free-choice-pronoun-(cxn)">
 <h2 class="name"><a href="#free-choice-pronoun-(cxn)">free choice pronoun (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#free-choice-referent-(inf)-pronoun-(cxn)">free choice referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>free choice pronoun (<i>cxn</i>)</strong></span><span><a href="#free-choice-referent-(inf)">free choice referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">free choice pronoun</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -7654,17 +6685,12 @@
 <strong>free choice pronoun (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <pronoun> that expresses a <a href="#free-choice-referent-(inf)">free choice referent</a>. <em>Example</em>: in <em>After the fall of the Wall, East Germans were free to travel anywhere</em>, <em>anywhere</em> is a free choice pronoun expressing a referent – a place – toward which the agent in the clause, the East Germans, is free to choose to travel. (Section 3.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="free-choice-referent-(inf)">
 <h2 class="name"><a href="#free-choice-referent-(inf)">free choice referent (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#free-choice-referent-(inf)-pronoun-(cxn)">free choice referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#free-choice-pronoun-(cxn)">free choice pronoun (<i>cxn</i>)</a></span><span><strong>free choice referent (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">free choice referent</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -7676,19 +6702,6 @@
 <strong>free choice referent (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="free-choice-referent-(inf)-pronoun-(cxn)">
-<h2 class="name"><a href="#free-choice-referent-(inf)-pronoun-(cxn)">free choice referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>free choice referent (<i>inf</i>) / pronoun (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#free-choice-pronoun-(cxn)">free choice pronoun (<i>cxn</i>)</a></span><span><a href="#free-choice-referent-(inf)">free choice referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">free choice referent/pronoun | free choice</td></tr>
 <tr><th>Definition</th> <td class="ccinfo definition">an unspecified <a href="#reference,-referent-(inf)">referent</a> in certain contexts, whose identity can be freely chosen without affecting the truth value of the utterance. <em>Example</em>: in <em>After the fall of the Wall, East Germans were free to travel anywhere</em>, <em>anywhere</em> is a free choice pronoun expressing a referent – a place – toward which the agent in the clause, the East Germans, is free to choose to travel. (Section 3.5)</td></tr>
 </table>
 </div>
@@ -7707,7 +6720,7 @@
 <strong>free relative clause (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#relative-clause-construction-(cxn)">relative clause construction</a> in which the head has one of several possible <a href="#indefinite-pronoun-article-(cxn)">indefinite</a> functions – that is, <a href="#specific-known-referent-(inf)-pronoun-(cxn)">specific</a>, <a href="#irrealis-referent-(inf)-pronoun-(cxn)">irrealis</a>, <a href="#free-choice-referent-(inf)-pronoun-(cxn)">free choice</a>, and/or <a href="#universal-pronoun-(cxn)">universal</a>. <em>Example</em>: in <em>Take what(ever) you like</em>, <em>what(ever) you like</em> is a free relative clause using a <a href="#headless-(str)">headless strategy</a>, and in <em>Take anything you like</em>, <em>anything you like</em> is a free relative clause using an <a href="#overtly-headed-strategy-(str)">overt head strategy</a>. (Section 19.4)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#relative-clause-construction-(cxn)">relative clause construction</a> in which the head has one of several possible <a href="#indefinite-pronoun-(cxn)">indefinite</a> functions – that is, <a href="#specific-known-referent-(inf)">specific</a>, <a href="#irrealis-referent-(inf)">irrealis</a>, <a href="#free-choice-referent-(inf)">free choice</a>, and/or <a href="#universal-pronoun-(cxn)">universal</a>. <em>Example</em>: in <em>Take what(ever) you like</em>, <em>what(ever) you like</em> is a free relative clause using a <a href="#headless-(str)">headless strategy</a>, and in <em>Take anything you like</em>, <em>anything you like</em> is a free relative clause using an <a href="#overtly-headed-strategy-(str)">overt head strategy</a>. (Section 19.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="function-(def)">
@@ -7871,12 +6884,6 @@
 <div class="cc" id="generic-conditional-construction-(cxn)">
 <h2 class="name"><a href="#generic-conditional-construction-(cxn)">generic conditional construction (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#generic-conditional-relation-(sem)-construction-(cxn)">generic conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>generic conditional construction (<i>cxn</i>)</strong></span><span><a href="#generic-conditional-relation-(sem)">generic conditional relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">generic conditional construction</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -7888,19 +6895,14 @@
 <strong>generic conditional construction (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a construction that expresses a <a href="#generic-conditional-relation-(sem)">generic conditional relation</a>. <em>Example</em>: <em>If/When/Whenever a dog starts barking, I run away</em> is an instance of a generic conditional relation and construction – it doesn't describe a specific instance of a dog barking causing me to run away; instead, it describes a general or habitual pattern of this causal sequence of events. (Section 17.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="generic-conditional-relation-(sem)">
 <h2 class="name"><a href="#generic-conditional-relation-(sem)">generic conditional relation (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#generic-conditional-relation-(sem)-construction-(cxn)">generic conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#generic-conditional-construction-(cxn)">generic conditional construction (<i>cxn</i>)</a></span><span><strong>generic conditional relation (<i>sem</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">generic conditional relation</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">generic conditional relation | generic conditional</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -7910,20 +6912,7 @@
 <strong>generic conditional relation (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="generic-conditional-relation-(sem)-construction-(cxn)">
-<h2 class="name"><a href="#generic-conditional-relation-(sem)-construction-(cxn)">generic conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>generic conditional relation (<i>sem</i>) / construction (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#generic-conditional-construction-(cxn)">generic conditional construction (<i>cxn</i>)</a></span><span><a href="#generic-conditional-relation-(sem)">generic conditional relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">generic conditional relation/construction | generic conditional</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a subtype of the conditional relation in which an event causes another event generically or habitually. <em>Example</em>: <em>If/When/Whenever a dog starts barking, I run away</em> is an instance of a generic conditional relation and construction – it doesn't describe a specific instance of a dog barking causing me to run away; instead, it describes a general or habitual pattern of this causal sequence of events. (Section 17.3.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a subtype of the <a href="#conditional-relation-(sem)">conditional relation</a> in which an event causes another event generically or habitually. <em>Example</em>: <em>If/When/Whenever a dog starts barking, I run away</em> is an instance of a generic conditional relation and construction – it doesn't describe a specific instance of a dog barking causing me to run away; instead, it describes a general or habitual pattern of this causal sequence of events. (Section 17.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="generic-pronoun-(cxn)">
@@ -8083,14 +7072,8 @@
 <div class="cc" id="hoping-event-(sem)">
 <h2 class="name"><a href="#hoping-event-(sem)">hoping event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#hoping-event-(sem)-predicate-(cxn)">hoping event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>hoping event (<i>sem</i>)</strong></span><span><a href="#hoping-predicate-(cxn)">hoping predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">hoping event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">hoping event | hoping</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#neutral-epistemic-stance-(sem)">neutral epistemic stance (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -8101,31 +7084,12 @@
 <strong>hoping event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="hoping-event-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#hoping-event-(sem)-predicate-(cxn)">hoping event (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>hoping event (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#hoping-event-(sem)">hoping event (<i>sem</i>)</a></span><span><a href="#hoping-predicate-(cxn)">hoping predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">hoping event/predicate | hoping</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#evaluative-event-(sem)">evaluative event</a> in which a positive evaluative judgment about a <a href="#proposition-(sem)">proposition</a> expressed by the <a href="#complement-dependent-clause-(cxn)">complement</a> of the commentative event is made, and there is a <a href="#neutral-epistemic-stance-(sem)">neutral epistemic stance</a> by the speaker toward the proposition; and the predicate expressing such an event. <em>Example</em>: in <em>Jill hopes that Joe won the election</em>, the commentative predicate <em>hopes</em> expresses Jill's evaluation of Joe's winning the election, and also presupposes that the speaker does not know whether Joe has won the election. (Section 18.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#evaluative-event-(sem)">evaluative event</a> in which a positive evaluative judgment about a <a href="#proposition-(sem)">proposition</a> expressed by the <a href="#complement-dependent-clause-(cxn)">complement</a> of the commentative event is made, and there is a <a href="#neutral-epistemic-stance-(sem)">neutral epistemic stance</a> by the speaker toward the proposition. <em>Example</em>: in <em>Jill hopes that Joe won the election</em>, the commentative predicate <em>hopes</em> expresses Jill's evaluation of Joe's winning the election, and also presupposes that the speaker does not know whether Joe has won the election. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="hoping-predicate-(cxn)">
 <h2 class="name"><a href="#hoping-predicate-(cxn)">hoping predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#hoping-event-(sem)-predicate-(cxn)">hoping event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#hoping-event-(sem)">hoping event (<i>sem</i>)</a></span><span><strong>hoping predicate (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">hoping predicate</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -8137,6 +7101,7 @@
 <strong>hoping predicate (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the predicate expressing a <a href="#hoping-event-(sem)">hoping event</a>. <em>Example</em>: in <em>Jill hopes that Joe won the election</em>, the commentative predicate <em>hopes</em> expresses Jill's evaluation of Joe's winning the election, and also presupposes that the speaker does not know whether Joe has won the election. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="human-(sem)">
@@ -8239,12 +7204,6 @@
 <div class="cc" id="identificational-(cxn)">
 <h2 class="name"><a href="#identificational-(cxn)">identificational (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#identificational-(inf-cxn)">identificational (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>identificational (<i>cxn</i>)</strong></span><span><a href="#identificational-(inf)">identificational (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">identificational</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -8260,31 +7219,12 @@
 <span><a href="#polarity-focus-construction-(cxn)">polarity focus construction (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="identificational-(inf-cxn)">
-<h2 class="name"><a href="#identificational-(inf-cxn)">identificational (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>identificational (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#identificational-(cxn)">identificational (<i>cxn</i>)</a></span><span><a href="#identificational-(inf)">identificational (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">identificational</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition"><a href="#information-packaging-(def)">information packaging</a> in which a particular piece of information (the <a href="#focus-(inf)">focus</a>) is equated with the <q class="dq">open slot</q> in a <a href="#presupposed-open-proposition-(inf)">presupposed open proposition</a>; and the <a href="#construction-(def)">construction</a> that expresses that information packaging. The presupposed open proposition may be evoked by an alternative proposition that differs from the identificational construction by only the focus. <em>Example</em>: in <em>It was Ollie who was playing the piano</em>, the information in the identificational construction is divided into the presupposed open proposition <q>X was playing the piano</q>, and the focused information Ollie, and what is being asserted is <q>X = Ollie</q>. The term <q>focus</q> is sometimes used as a synonym for <q>identificational</q>, but this term is used differently here. (Sections 10.1.2, 11.1, <strong>11.4.1</strong>)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> that expresses a <a href="#identificational-(inf)">identificational</a> information packaging. The presupposed open proposition may be evoked by an alternative proposition that differs from the identificational construction by only the focus. <em>Example</em>: in <em>It was Ollie who was playing the piano</em>, the information in the identificational construction is divided into the presupposed open proposition <q>X was playing the piano</q>, and the focused information Ollie, and what is being asserted is <q>X = Ollie</q>. The term <q>focus</q> is sometimes used as a synonym for <q>identificational</q>, but this term is used differently here. (Sections 10.1.2, 11.1, <strong>11.4.1</strong>)</td></tr>
 </table>
 </div>
 <div class="cc" id="identificational-(inf)">
 <h2 class="name"><a href="#identificational-(inf)">identificational (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#identificational-(inf-cxn)">identificational (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#identificational-(cxn)">identificational (<i>cxn</i>)</a></span><span><strong>identificational (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">identificational</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -8299,6 +7239,7 @@
 <span><a href="#equational-(inf)">equational (<i>inf</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition"><a href="#information-packaging-(def)">information packaging</a> in which a particular piece of information (the <a href="#focus-(inf)">focus</a>) is equated with the <q class="dq">open slot</q> in a <a href="#presupposed-open-proposition-(inf)">presupposed open proposition</a>. The presupposed open proposition may be evoked by an alternative proposition that differs from the identificational construction by only the focus. <em>Example</em>: in <em>It was Ollie who was playing the piano</em>, the information in the identificational construction is divided into the presupposed open proposition <q>X was playing the piano</q>, and the focused information Ollie, and what is being asserted is <q>X = Ollie</q>. The term <q>focus</q> is sometimes used as a synonym for <q>identificational</q>, but this term is used differently here. (Sections 10.1.2, 11.1, <strong>11.4.1</strong>)</td></tr>
 </table>
 </div>
 <div class="cc" id="identity-statements-(def)">
@@ -8335,12 +7276,6 @@
 <div class="cc" id="imperative-hortative-(cxn)">
 <h2 class="name"><a href="#imperative-hortative-(cxn)">imperative–hortative (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#imperative-hortative-(inf-cxn)">imperative–hortative (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>imperative–hortative (<i>cxn</i>)</strong></span><span><a href="#imperative-hortative-(inf)">imperative–hortative (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">imperative–hortative | imperative | hortative</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -8355,31 +7290,12 @@
 <span><a href="#prohibitive-(cxn)">prohibitive (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="imperative-hortative-(inf-cxn)">
-<h2 class="name"><a href="#imperative-hortative-(inf-cxn)">imperative–hortative (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>imperative–hortative (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#imperative-hortative-(cxn)">imperative–hortative (<i>cxn</i>)</a></span><span><a href="#imperative-hortative-(inf)">imperative–hortative (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">imperative–hortative | imperative | hortative | jussive</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#speech-acts-(inf)">speech act</a> which requests that the action expressed in the propositional content of the imperative–hortative be carried out, prototypically by the addressee but possibly by other persons; and the <a href="#construction-(def)">construction</a> that expresses this speech act. <em>Example</em>: <em>Dance!</em> is an example of the English imperative–hortative construction for the <a href="#person-(sem)">second person</a>, and <em>Let's dance!</em> is an example of the same for the <a href="#person-(sem)">first person</a> <span class="separation"/> <a href="#number-(sem)">plural</a>. The term <q>hortative</q> is sometimes used for a first person imperative–hortative, and <q>jussive</q> for a third person imperative–hortative. A negative imperative–hortative is a <a href="#prohibitive-(inf)">prohibitive</a>. (Sections 12.1, 12.4)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> that expresses a <a href="#imperative-hortative-(inf)">imperative–hortative</a> speech act. <em>Example</em>: <em>Dance!</em> is an example of the English imperative–hortative construction for the <a href="#person-(sem)">second person</a>, and <em>Let's dance!</em> is an example of the same for the <a href="#person-(sem)">first person</a> <span class="separation"/> <a href="#number-(sem)">plural</a>. The term <q>hortative</q> is sometimes used for a first person imperative–hortative, and <q>jussive</q> for a third person imperative–hortative. A negative imperative–hortative is a <a href="#prohibitive-(inf)">prohibitive</a>. (Sections 12.1, 12.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="imperative-hortative-(inf)">
 <h2 class="name"><a href="#imperative-hortative-(inf)">imperative–hortative (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#imperative-hortative-(inf-cxn)">imperative–hortative (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#imperative-hortative-(cxn)">imperative–hortative (<i>cxn</i>)</a></span><span><strong>imperative–hortative (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">imperative–hortative | imperative | hortative</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -8394,6 +7310,7 @@
 <span><a href="#prohibitive-(inf)">prohibitive (<i>inf</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#speech-acts-(inf)">speech act</a> which requests that the action expressed in the propositional content of the imperative–hortative be carried out, prototypically by the addressee but possibly by other persons. <em>Example</em>: <em>Dance!</em> is an example of the English imperative–hortative construction for the <a href="#person-(sem)">second person</a>, and <em>Let's dance!</em> is an example of the same for the <a href="#person-(sem)">first person</a> <span class="separation"/> <a href="#number-(sem)">plural</a>. The term <q>hortative</q> is sometimes used for a first person imperative–hortative, and <q>jussive</q> for a third person imperative–hortative. A negative imperative–hortative is a <a href="#prohibitive-(inf)">prohibitive</a>. (Sections 12.1, 12.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="inactive-(inf)">
@@ -8539,12 +7456,6 @@
 <div class="cc" id="indefinite-article-(cxn)">
 <h2 class="name"><a href="#indefinite-article-(cxn)">indefinite article (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#indefinite-pronoun-article-(cxn)">indefinite pronoun/article (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>indefinite article (<i>cxn</i>)</strong></span><span><a href="#indefinite-pronoun-(cxn)">indefinite pronoun (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">indefinite article</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -8556,17 +7467,12 @@
 <strong>indefinite article (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#article-(cxn)">article</a> that is associated with the bottom end of the <a href="#information-status-(inf)">information status</a> continuum, where the identity of the referent is not known to speaker or hearer (or both). This includes <a href="#pragmatically-specific-indefinite-referent-(inf)">pragmatically specific</a>, <a href="#pragmatically-nonspecific-but-semantically-specific-indefinite-referent-(inf)">pragmatically nonspecific (but semantically specific)</a>, and various categories of <a href="#nonspecific-referent-(inf)">nonspecific referents</a> (see Table 3.4 and Sections 3.4–3.5). <em>Example</em>: <em>a bowl</em> is an example of an indefinite article <em>a</em> combined with a <a href="#common-noun-(cxn)">common noun</a> bowl, used in a context where the individual bowl in question is not identifiable by the hearer. (Table 3.4, Section 3.3.1) </td></tr>
 </table>
 </div>
 <div class="cc" id="indefinite-pronoun-(cxn)">
 <h2 class="name"><a href="#indefinite-pronoun-(cxn)">indefinite pronoun (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#indefinite-pronoun-article-(cxn)">indefinite pronoun/article (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#indefinite-article-(cxn)">indefinite article (<i>cxn</i>)</a></span><span><strong>indefinite pronoun (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">indefinite pronoun</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -8578,20 +7484,7 @@
 <strong>indefinite pronoun (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="indefinite-pronoun-article-(cxn)">
-<h2 class="name"><a href="#indefinite-pronoun-article-(cxn)">indefinite pronoun/article (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>indefinite pronoun/article (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#indefinite-article-(cxn)">indefinite article (<i>cxn</i>)</a></span><span><a href="#indefinite-pronoun-(cxn)">indefinite pronoun (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">indefinite pronoun/article</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">this term is applied to <a href="#referring-phrase-(cxn)">referring phrases</a> – <a href="#pronoun-(cxn)">pronouns</a> and <a href="#article-(cxn)">articles</a> combined with <a href="#noun-(cxn)">nouns</a> – that are associated with the bottom end of the <a href="#information-status-(inf)">information status</a> continuum, where the identity of the referent is not known to speaker or hearer (or both). This includes <a href="#pragmatically-specific-indefinite-referent-(inf)-article-(cxn)">pragmatically specific</a>, <a href="#pragmatically-nonspecific-but-semantically-specific-indefinite-referent-(inf)-article-(cxn)">pragmatically nonspecific (but semantically specific)</a>, and various categories of <a href="#nonspecific-referent-(inf)-article-(cxn)-pronoun-(cxn)">nonspecific</a> referents (see Table 3.4 and Sections 3.4–3.5). <em>Example</em>: <em>a glass bowl</em> is an example of an indefinite referring phrase, used in a context where the individual glass bowl in question is not identifiable by the hearer. (Table 3.4, Section 3.3.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#pronoun-(cxn)">pronoun</a> that is associated with the bottom end of the <a href="#information-status-(inf)">information status</a> continuum, where the identity of the <a href="#reference,-referent-(inf)">referent</a> is not known to speaker or hearer (or both). This includes <a href="#pragmatically-specific-indefinite-referent-(inf)">pragmatically specific</a>, <a href="#pragmatically-nonspecific-but-semantically-specific-indefinite-referent-(inf)">pragmatically nonspecific (but semantically specific)</a>, and various categories of <a href="#nonspecific-referent-(inf)">nonspecific referents</a> (see Table 3.4 and Sections 3.4–3.5). <em>Example</em>: in <em>Something is under the bed</em>, <em>something</em> is an example of an indefinite pronoun, used in a context where the referent is not identifiable by the hearer. (Table 3.4, Section 3.3.1) </td></tr>
 </table>
 </div>
 <div class="cc" id="independent-referring-phrase-strategy-(str)">
@@ -8631,7 +7524,7 @@
 <span><a href="#particle-comparative-(str)">particle comparative (<i>str</i>)</a></span>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#strategy-(def)">strategy</a> for <a href="#comparative-referent-(inf)-pronoun-(cxn)">comparative</a> (and possibly <a href="#equative-construction-(cxn)">equative</a>) <a href="#construction-(def)">constructions</a> which directly expresses two of the <a href="#proposition-(sem)">propositions</a> that form the <a href="#meaning-(def)">meaning</a> of the <a href="#comparative-referent-(inf)-pronoun-(cxn)">comparative</a>: that the <a href="#gradable-predicative-scale-(sem)">gradable predicative scale</a> applies to the <a href="#comparee-(sem)">comparee</a>, and that the scale applies to the <a href="#standard-(sem)">standard</a>. That is to say, the independent strategy <a href="#recruitment-strategy-(str)">recruits</a> a <a href="#different-subject-(inf)">different-subject</a>, <a href="#simultaneous-(sem)">simultaneous</a> <u>temporal</u> <a href="#complex-sentence-(cxn)">complex sentence construction</a> (usually a <a href="#coordinate-clause-construction-(cxn)">coordinate clause construction</a>) to express comparison. The <a href="#conjoined-comparative-(str)">conjoined comparative</a> and <a href="#particle-comparative-(str)">particle</a> <span class="separation"/> <a href="#strategy-(def)">strategies</a> are examples of the independent strategy. (Section 17.2.3)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#strategy-(def)">strategy</a> for <a href="#comparative-construction-(cxn)">comparative</a> (and possibly <a href="#equative-construction-(cxn)">equative</a>) <a href="#construction-(def)">constructions</a> which directly expresses two of the <a href="#proposition-(sem)">propositions</a> that form the <a href="#meaning-(def)">meaning</a> of the <a href="#comparative-construction-(cxn)">comparative</a>: that the <a href="#gradable-predicative-scale-(sem)">gradable predicative scale</a> applies to the <a href="#comparee-(sem)">comparee</a>, and that the scale applies to the <a href="#standard-(sem)">standard</a>. That is to say, the independent strategy <a href="#recruitment-strategy-(str)">recruits</a> a <a href="#different-subject-(inf)">different-subject</a>, <a href="#simultaneous-(sem)">simultaneous</a> <u>temporal</u> <a href="#complex-sentence-(cxn)">complex sentence construction</a> (usually a <a href="#coordinate-clause-construction-(cxn)">coordinate clause construction</a>) to express comparison. The <a href="#conjoined-comparative-(str)">conjoined comparative</a> and <a href="#particle-comparative-(str)">particle</a> <span class="separation"/> <a href="#strategy-(def)">strategies</a> are examples of the independent strategy. (Section 17.2.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="independent-time-reference-(sem)">
@@ -8756,12 +7649,6 @@
 <div class="cc" id="indirect-negation-pronoun-(cxn)">
 <h2 class="name"><a href="#indirect-negation-pronoun-(cxn)">indirect negation pronoun (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#indirect-negation-referent-(inf)-pronoun-(cxn)">indirect negation referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>indirect negation pronoun (<i>cxn</i>)</strong></span><span><a href="#indirect-negation-referent-(inf)">indirect negation referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">indirect negation pronoun</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -8773,17 +7660,12 @@
 <strong>indirect negation pronoun (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <pronoun> that expresses an <a href="#indirect-negation-referent-(inf)">indirect negation referent</a>. <em>Example</em>: in <em>I don't think that anybody has seen it</em>, <em>anybody</em> is an indirect negation pronoun expressing a referent that is found only in the negated <q class="dq">world</q> of the speaker's beliefs. (Section 3.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="indirect-negation-referent-(inf)">
 <h2 class="name"><a href="#indirect-negation-referent-(inf)">indirect negation referent (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#indirect-negation-referent-(inf)-pronoun-(cxn)">indirect negation referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#indirect-negation-pronoun-(cxn)">indirect negation pronoun (<i>cxn</i>)</a></span><span><strong>indirect negation referent (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">indirect negation referent</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -8795,19 +7677,6 @@
 <strong>indirect negation referent (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="indirect-negation-referent-(inf)-pronoun-(cxn)">
-<h2 class="name"><a href="#indirect-negation-referent-(inf)-pronoun-(cxn)">indirect negation referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>indirect negation referent (<i>inf</i>) / pronoun (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#indirect-negation-pronoun-(cxn)">indirect negation pronoun (<i>cxn</i>)</a></span><span><a href="#indirect-negation-referent-(inf)">indirect negation referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">indirect negation referent/pronoun | indirect negation</td></tr>
 <tr><th>Definition</th> <td class="ccinfo definition">an unspecified <a href="#reference,-referent-(inf)">referent</a> which is in a <a href="#clause-(cxn)">clause</a> embedded in a <a href="#negative-polarity-(sem)">negated</a> clause. <em>Example</em>: in <em>I don't think that anybody has seen it</em>, <em>anybody</em> is an indirect negation pronoun expressing a referent that is found only in the negated <q class="dq">world</q> of the speaker's beliefs. (Section 3.5)</td></tr>
 </table>
 </div>
@@ -8904,12 +7773,6 @@
 <div class="cc" id="information-question-response-(cxn)">
 <h2 class="name"><a href="#information-question-response-(cxn)">information (question) response (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#information-question-response-(inf-cxn)">information (question) response (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>information (question) response (<i>cxn</i>)</strong></span><span><a href="#information-question-response-(inf)">information (question) response (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">information (question) response | information question response | information response</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -8921,31 +7784,12 @@
 <strong>information (question) response (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="information-question-response-(inf-cxn)">
-<h2 class="name"><a href="#information-question-response-(inf-cxn)">information (question) response (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>information (question) response (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#information-question-response-(cxn)">information (question) response (<i>cxn</i>)</a></span><span><a href="#information-question-response-(inf)">information (question) response (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">information (question) response | information question response | information response</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the answer to an <a href="#information-question-(inf)">information question</a>, and the <a href="#construction-(def)">construction</a> that expresses that answer. <em>Example</em>: the answer to the English information question <em>Who is coming?</em> could be <em>Sandra is coming, Sandra is</em>, or just <em>Sandra</em>. (Section 12.3.3)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> that expresses the <a information (question) response>answer to an information question<a>. <em>Example</em>: the answer to the English information question <em>Who is coming?</em> could be <em>Sandra is coming, Sandra is</em>, or just <em>Sandra</em>. (Section 12.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="information-question-response-(inf)">
 <h2 class="name"><a href="#information-question-response-(inf)">information (question) response (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#information-question-response-(inf-cxn)">information (question) response (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#information-question-response-(cxn)">information (question) response (<i>cxn</i>)</a></span><span><strong>information (question) response (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">information (question) response | information question response | information response</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -8957,6 +7801,7 @@
 <strong>information (question) response (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the answer to an <a href="#information-question-(inf)">information question</a>. <em>Example</em>: the answer to the English information question <em>Who is coming?</em> could be <em>Sandra is coming, Sandra is</em>, or just <em>Sandra</em>. (Section 12.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="information-element-FN-Br-(inf)">
@@ -9038,12 +7883,6 @@
 <div class="cc" id="information-question-(cxn)">
 <h2 class="name"><a href="#information-question-(cxn)">information question (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#information-question-(inf-cxn)">information question (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>information question (<i>cxn</i>)</strong></span><span><a href="#information-question-(inf)">information question (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">information question</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -9055,31 +7894,12 @@
 <strong>information question (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="information-question-(inf-cxn)">
-<h2 class="name"><a href="#information-question-(inf-cxn)">information question (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>information question (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#information-question-(cxn)">information question (<i>cxn</i>)</a></span><span><a href="#information-question-(inf)">information question (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">information question | content question | WH question</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#interrogative-(inf)">interrogative</a> in which the unknown piece of the <a href="#propositional-content-(sem)">propositional content</a> requested of the addressee is a semantic component of the <a href="#proposition-(sem)">proposition</a> other than its <a href="#polarity-(sem)">polarity</a>; and the <a href="#construction-(def)">construction</a> expressing this <a href="#role-(def)">function</a>. <em>Example</em>: <em>Who is coming?</em> is an instance of the English information question construction, expecting an answer identifying the person(s) who is/are coming. Information questions, unlike <a href="#polarity-question-(inf)">polarity questions</a>, contain an <a href="#interrogative-pronoun-(cxn)">interrogative pronoun</a>. (Section 12.3.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> expressing an <a href="#information-question-(inf)">information question</a> <span class="separation"/> <a href="#role-(def)">function</a>. <em>Example</em>: <em>Who is coming?</em> is an instance of the English information question construction, expecting an answer identifying the person(s) who is/are coming. Information questions, unlike <a href="#polarity-question-(inf)">polarity questions</a>, contain an <a href="#interrogative-pronoun-(cxn)">interrogative pronoun</a>. (Section 12.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="information-question-(inf)">
 <h2 class="name"><a href="#information-question-(inf)">information question (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#information-question-(inf-cxn)">information question (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#information-question-(cxn)">information question (<i>cxn</i>)</a></span><span><strong>information question (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">information question</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -9091,6 +7911,7 @@
 <strong>information question (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#interrogative-(inf)">interrogative</a> in which the unknown piece of the <a href="#propositional-content-(sem)">propositional content</a> requested of the addressee is a semantic component of the <a href="#proposition-(sem)">proposition</a> other than its <a href="#polarity-(sem)">polarity</a>. <em>Example</em>: <em>Who is coming?</em> is an instance of the English information question construction, expecting an answer identifying the person(s) who is/are coming. (Section 12.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="information-status-(inf)">
@@ -9121,12 +7942,6 @@
 <div class="cc" id="ingestion-event-(sem)">
 <h2 class="name"><a href="#ingestion-event-(sem)">ingestion event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#ingestion-event-(sem)-verb-(cxn)">ingestion event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>ingestion event (<i>sem</i>)</strong></span><span><a href="#ingestion-verb-(cxn)">ingestion verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">ingestion event</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -9138,31 +7953,12 @@
 <strong>ingestion event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="ingestion-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#ingestion-event-(sem)-verb-(cxn)">ingestion event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>ingestion event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#ingestion-event-(sem)">ingestion event (<i>sem</i>)</a></span><span><a href="#ingestion-verb-(cxn)">ingestion verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">ingestion event/verb | ingestion</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> which describes the ingestion of food or drink by a person or animal, causing the food to disappear but also causing a change in the physiological state of the person/animal; and a <a href="#verb-(cxn)">verb</a> that expresses such an event. <em>Example</em>: <em>Elena ate a lot of veggie chips</em> is an instance of an ingestion event, and <em>eat</em> is an ingestion verb. (Section 7.4)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> which describes the ingestion of food or drink by a person or animal, causing the food to disappear but also causing a change in the physiological state of the person/animal. <em>Example</em>: <em>Elena ate a lot of veggie chips</em> is an instance of an ingestion event. (Section 7.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="ingestion-verb-(cxn)">
 <h2 class="name"><a href="#ingestion-verb-(cxn)">ingestion verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#ingestion-event-(sem)-verb-(cxn)">ingestion event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#ingestion-event-(sem)">ingestion event (<i>sem</i>)</a></span><span><strong>ingestion verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">ingestion verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -9174,6 +7970,7 @@
 <strong>ingestion verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#verb-(cxn)">verb</a> that expresses an <a href="#ingestion-event-(sem)">ingestion event</a>. <em>Example</em>: <em>Elena ate a lot of veggie chips</em> is an instance of an ingestion event, and <em>eat</em> is an ingestion verb. (Section 7.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="initiator-(sem)">
@@ -9249,12 +8046,6 @@
 <div class="cc" id="interaction-event-(sem)">
 <h2 class="name"><a href="#interaction-event-(sem)">interaction event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#interaction-event-(sem)-verb-(cxn)">interaction event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>interaction event (<i>sem</i>)</strong></span><span><a href="#interaction-verb-(cxn)">interaction verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">interaction event</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -9266,31 +8057,12 @@
 <strong>interaction event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="interaction-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#interaction-event-(sem)-verb-(cxn)">interaction event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>interaction event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#interaction-event-(sem)">interaction event (<i>sem</i>)</a></span><span><a href="#interaction-verb-(cxn)">interaction verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">interaction event/verb | interaction</td></tr>
 <tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> in which one <a href="#participant-(sem)">participant</a> acts on a second participant, but the change that occurs to the second participant is at least partly independent of the <a href="#force-(sem)">force</a> <u>transmitted</u> by the first participant. <em>Examples</em>: interaction events include <a href="#pursuit-event-(sem)">pursuit events</a>, events involving two agents such as ordering someone (to do something) or supervising someone, and events involving an agent and an event, state, social institution, and so on, such as managing a budget, avoiding situations, or conforming to institutional standards. (Section 7.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="interaction-verb-(cxn)">
 <h2 class="name"><a href="#interaction-verb-(cxn)">interaction verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#interaction-event-(sem)-verb-(cxn)">interaction event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#interaction-event-(sem)">interaction event (<i>sem</i>)</a></span><span><strong>interaction verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">interaction verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -9302,6 +8074,7 @@
 <strong>interaction verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#verb-(cxn)">verb</a> that expresses an <a href="#interaction-event-(sem)">interaction event</a>. (Section 7.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="interlinear-morpheme-translation-(def)">
@@ -9373,12 +8146,6 @@
 <div class="cc" id="interrogative-(cxn)">
 <h2 class="name"><a href="#interrogative-(cxn)">interrogative (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#interrogative-(inf-cxn)">interrogative (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>interrogative (<i>cxn</i>)</strong></span><span><a href="#interrogative-(inf)">interrogative (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">interrogative</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -9395,31 +8162,12 @@
 <span><a href="#polarity-question-(cxn)">polarity question (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="interrogative-(inf-cxn)">
-<h2 class="name"><a href="#interrogative-(inf-cxn)">interrogative (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>interrogative (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#interrogative-(cxn)">interrogative (<i>cxn</i>)</a></span><span><a href="#interrogative-(inf)">interrogative (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">interrogative | question</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#speech-acts-(inf)">speech act</a> which requests information, usually of the addressee, regarding uncertain or unknown information that is part of the <a href="#propositional-content-(sem)">propositional content</a> of the question; and the <a href="#construction-(def)">construction</a> that expresses this speech act. Interrogatives are divided into <a href="#polarity-question-(inf)">polarity questions</a>, <a href="#information-question-(inf)">information questions</a>, and <a href="#alternative-question-(inf)">alternative questions</a>. (Sections 12.1, 12.3)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> that expresses a <a href="#interrogative-(inf)">interrogative</a> speech act. Interrogatives are divided into <a href="#polarity-question-(inf)">polarity questions</a>, <a href="#information-question-(inf)">information questions</a>, and <a href="#alternative-question-(inf)">alternative questions</a>. (Sections 12.1, 12.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="interrogative-(inf)">
 <h2 class="name"><a href="#interrogative-(inf)">interrogative (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#interrogative-(inf-cxn)">interrogative (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#interrogative-(cxn)">interrogative (<i>cxn</i>)</a></span><span><strong>interrogative (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">interrogative</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -9436,6 +8184,7 @@
 <span><a href="#polarity-question-(inf)">polarity question (<i>inf</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#speech-acts-(inf)">speech act</a> which requests information, usually of the addressee, regarding uncertain or unknown information that is part of the <a href="#propositional-content-(sem)">propositional content</a> of the question. Interrogatives are divided into <a href="#polarity-question-(inf)">polarity questions</a>, <a href="#information-question-(inf)">information questions</a>, and <a href="#alternative-question-(inf)">alternative questions</a>. (Sections 12.1, 12.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="interrogative-complement-(cxn)">
@@ -9452,7 +8201,7 @@
 <strong>interrogative complement (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#complement-dependent-clause-(cxn)">complement</a> that expresses a <a href="#proposition-(sem)">proposition</a> which contains information that is unknown. Interrogative complements commonly occur in certain types of <a href="#propositional-attitude-event-(sem)-predicate-(cxn)">propositional attitude</a> <span class="separation"/> <a href="#complement-clause-construction-(cxn)">complement clause constructions</a>. <em>Examples</em>: in <em>I wonder who is going to the party</em> or <em>John wondered whether he would go to the party</em>, <em>who is going to the party</em> and <em>whether he would go to the party</em> are interrogative complements. Interrogative complements are often found in the <a href="#objective-(sem)">objective</a> construal of <a href="#epistemic-modality-(sem)">epistemic modality</a>. (Sections 12.3.4, 18.3.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#complement-dependent-clause-(cxn)">complement</a> that expresses a <a href="#proposition-(sem)">proposition</a> which contains information that is unknown. Interrogative complements commonly occur in certain types of <a href="#propositional-attitude-event-(sem)">propositional attitude</a> <span class="separation"/> <a href="#complement-clause-construction-(cxn)">complement clause constructions</a>. <em>Examples</em>: in <em>I wonder who is going to the party</em> or <em>John wondered whether he would go to the party</em>, <em>who is going to the party</em> and <em>whether he would go to the party</em> are interrogative complements. Interrogative complements are often found in the <a href="#objective-(sem)">objective</a> construal of <a href="#epistemic-modality-(sem)">epistemic modality</a>. (Sections 12.3.4, 18.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="interrogative-pronoun-(cxn)">
@@ -9528,12 +8277,6 @@
 <div class="cc" id="introverted-event-(sem)">
 <h2 class="name"><a href="#introverted-event-(sem)">introverted event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#introverted-event-(sem)-verb-(cxn)">introverted event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>introverted event (<i>sem</i>)</strong></span><span><a href="#introverted-verb-(cxn)">introverted verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">introverted event</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -9545,31 +8288,12 @@
 <strong>introverted event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="introverted-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#introverted-event-(sem)-verb-(cxn)">introverted event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>introverted event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#introverted-event-(sem)">introverted event (<i>sem</i>)</a></span><span><a href="#introverted-verb-(cxn)">introverted verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">introverted event/verb | introverted</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> typically performed on oneself or by oneself, but that could be performed on someone else; and a <a href="#verb-(cxn)">verb</a> expressing such an event. <em>Examples</em>: shaving oneself vs. shaving someone else, laying down vs. laying someone else down, or quarreling (with each other) are instances of introverted events, and <em>shave</em>, <em>lay (down)</em>, and <em>quarrel</em> are introverted verbs. (Section 7.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> typically performed on oneself or by oneself, but that could be performed on someone else. <em>Examples</em>: shaving oneself vs. shaving someone else, laying down vs. laying someone else down, or quarreling (with each other) are instances of introverted events. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="introverted-verb-(cxn)">
 <h2 class="name"><a href="#introverted-verb-(cxn)">introverted verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#introverted-event-(sem)-verb-(cxn)">introverted event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#introverted-event-(sem)">introverted event (<i>sem</i>)</a></span><span><strong>introverted verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">introverted verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -9586,17 +8310,12 @@
 <span><a href="#change-in-body-position-verb-(cxn)">change in (body) position verb (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#verb-(cxn)">verb</a> expressing an <a href="#introverted-event-(sem)">introverted event</a>. <em>Examples</em>: shaving oneself vs. shaving someone else, laying down vs. laying someone else down, or quarreling (with each other) are instances of introverted events, and <em>shave</em>, <em>lay (down)</em>, and <em>quarrel</em> are introverted verbs. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="irrealis-pronoun-(cxn)">
 <h2 class="name"><a href="#irrealis-pronoun-(cxn)">irrealis pronoun (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#irrealis-referent-(inf)-pronoun-(cxn)">irrealis referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>irrealis pronoun (<i>cxn</i>)</strong></span><span><a href="#irrealis-referent-(inf)">irrealis referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">irrealis pronoun</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -9608,19 +8327,14 @@
 <strong>irrealis pronoun (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <pronoun> that expresses an <a href="#irrealis-referent-(inf)">irrealis referent</a>. <em>Example</em>: in <em>Visit me sometime</em>, <em>sometime</em> is an irrealis <a href="#pronoun-(cxn)">pronoun</a> expressing an irrealis referent – a time only found in the hoped-for mental space of the speaker's offer. (Section 3.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="irrealis-referent-(inf)">
 <h2 class="name"><a href="#irrealis-referent-(inf)">irrealis referent (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#irrealis-referent-(inf)-pronoun-(cxn)">irrealis referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#irrealis-pronoun-(cxn)">irrealis pronoun (<i>cxn</i>)</a></span><span><strong>irrealis referent (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">irrealis referent</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">irrealis referent | irrealis</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -9630,19 +8344,6 @@
 <strong>irrealis referent (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="irrealis-referent-(inf)-pronoun-(cxn)">
-<h2 class="name"><a href="#irrealis-referent-(inf)-pronoun-(cxn)">irrealis referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>irrealis referent (<i>inf</i>) / pronoun (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#irrealis-pronoun-(cxn)">irrealis pronoun (<i>cxn</i>)</a></span><span><a href="#irrealis-referent-(inf)">irrealis referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">irrealis referent/pronoun | irrealis</td></tr>
 <tr><th>Definition</th> <td class="ccinfo definition">a <a href="#reference,-referent-(inf)">referent</a> which is in the <q class="dq">world</q> or <a href="#mental-space-(sem)">mental space</a> representing a person's desire, wish, command, etc. <em>Example</em>: in <em>Visit me sometime</em>, <em>sometime</em> is an irrealis <a href="#pronoun-(cxn)">pronoun</a> expressing an irrealis referent – a time only found in the hoped-for mental space of the speaker's offer. (Section 3.5)</td></tr>
 </table>
 </div>
@@ -9671,12 +8372,6 @@
 <div class="cc" id="killing-injuring-event-(sem)">
 <h2 class="name"><a href="#killing-injuring-event-(sem)">killing/injuring event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#killing-injuring-event-(sem)-verb-(cxn)">killing/injuring event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>killing/injuring event (<i>sem</i>)</strong></span><span><a href="#killing-injuring-verb-(cxn)">killing/injuring verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">killing/injuring event | killing event | injuring event</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -9688,31 +8383,12 @@
 <strong>killing/injuring event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="killing-injuring-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#killing-injuring-event-(sem)-verb-(cxn)">killing/injuring event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>killing/injuring event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#killing-injuring-event-(sem)">killing/injuring event (<i>sem</i>)</a></span><span><a href="#killing-injuring-verb-(cxn)">killing/injuring verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">killing/injuring event/verb | killing/injuring | killing event/verb | killing | injuring event/verb | injuring</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> describing the injuring of an individual, including to the point that the individual dies; and the <a href="#verb-(cxn)">verb</a> expressing such an event. <em>Example</em>: stabbing is a killing/injuring event, and <em>stab</em> is a killing/injuring verb. (Section 7.3.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> describing the injuring of an individual, including to the point that the individual dies. <em>Example</em>: stabbing is a killing/injuring event. (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="killing-injuring-verb-(cxn)">
 <h2 class="name"><a href="#killing-injuring-verb-(cxn)">killing/injuring verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#killing-injuring-event-(sem)-verb-(cxn)">killing/injuring event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#killing-injuring-event-(sem)">killing/injuring event (<i>sem</i>)</a></span><span><strong>killing/injuring verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">killing/injuring verb | killing verb | injuring verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -9725,6 +8401,7 @@
 <strong>killing/injuring verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing such a <a href="#killing-injuring-event-(sem)">killing/injuring event</a>. <em>Example</em>: stabbing is a killing/injuring event, and <em>stab</em> is a killing/injuring verb. (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="kinship-relation-(sem)">
@@ -9748,14 +8425,8 @@
 <div class="cc" id="knowledge-event-(sem)">
 <h2 class="name"><a href="#knowledge-event-(sem)">knowledge event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#knowledge-event-(sem)-predicate-(cxn)">knowledge event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>knowledge event (<i>sem</i>)</strong></span><span><a href="#knowledge-predicate-(cxn)">knowledge predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">knowledge event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">knowledge event | knowledge</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#epistemic-stance-(sem)">epistemic stance (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -9766,31 +8437,12 @@
 <strong>knowledge event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="knowledge-event-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#knowledge-event-(sem)-predicate-(cxn)">knowledge event (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>knowledge event (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#knowledge-event-(sem)">knowledge event (<i>sem</i>)</a></span><span><a href="#knowledge-predicate-(cxn)">knowledge predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">knowledge event/predicate | knowledge</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#propositional-attitude-event-(sem)">propositional attitude event</a> in which a <a href="#positive-epistemic-stance-(sem)">positive epistemic stance</a> toward the relevant <a href="#proposition-(sem)">proposition</a> expressed is presupposed to be taken by the <u>speaker</u>; and the <a href="#predicate-(cxn)">predicate</a> expressing such an event. <em>Example</em>: in <em>Sally knows that Donald won the election</em>, Sally's belief with respect to the proposition that Donald won the election is reported by the speaker; and, in addition, a <a href="#positive-epistemic-stance-(sem)">positive epistemic stance</a> is taken by the speaker toward that proposition (i.e., the speaker believes that Donald indeed won the election). (Section 18.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#propositional-attitude-event-(sem)">propositional attitude event</a> in which a <a href="#positive-epistemic-stance-(sem)">positive epistemic stance</a> toward the relevant <a href="#proposition-(sem)">proposition</a> expressed is presupposed to be taken by the <u>speaker</u>. <em>Example</em>: in <em>Sally knows that Donald won the election</em>, Sally's belief with respect to the proposition that Donald won the election is reported by the speaker; and, in addition, a <a href="#positive-epistemic-stance-(sem)">positive epistemic stance</a> is taken by the speaker toward that proposition (i.e., the speaker believes that Donald indeed won the election). (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="knowledge-predicate-(cxn)">
 <h2 class="name"><a href="#knowledge-predicate-(cxn)">knowledge predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#knowledge-event-(sem)-predicate-(cxn)">knowledge event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#knowledge-event-(sem)">knowledge event (<i>sem</i>)</a></span><span><strong>knowledge predicate (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">knowledge predicate</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -9802,6 +8454,7 @@
 <strong>knowledge predicate (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#predicate-(cxn)">predicate</a> expressing a <a href="#knowledge-event-(sem)">knowledge event</a>. <em>Example</em>: in <em>Sally knows that Donald won the election</em>, Sally's belief with respect to the proposition that Donald won the election is reported by the speaker; and, in addition, a <a href="#positive-epistemic-stance-(sem)">positive epistemic stance</a> is taken by the speaker toward that proposition (i.e., the speaker believes that Donald indeed won the election). (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="labile-(str)">
@@ -9948,7 +8601,7 @@
 <strong>location (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the combination of the <a href="#path-of-motion-event-(sem)-verb-(cxn)">path</a> and the <a href="#ground-(sem)">ground</a> in a <a href="#figure-ground-spatial-relation-(sem)">spatial figure–ground (locative) relation</a>. <em>Example</em>: in <em>The book is on the table</em>, the location is on the table – that is, the spatial location of the figure (the book) as defined by the path relating the location of the figure to the location of the ground. (Section 10.4.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the combination of the <a href="#path-of-motion-event-(sem)">path</a> and the <a href="#ground-(sem)">ground</a> in a <a href="#figure-ground-spatial-relation-(sem)">spatial figure–ground (locative) relation</a>. <em>Example</em>: in <em>The book is on the table</em>, the location is on the table – that is, the spatial location of the figure (the book) as defined by the path relating the location of the figure to the location of the ground. (Section 10.4.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="location-clause-(cxn)">
@@ -9969,7 +8622,7 @@
 <span><a href="#presentational-location-(cxn)">presentational location (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#clause-(cxn)">clause</a> in which a locative relation is expressed, either <a href="#predicational-(inf)">predicationally</a> or <a href="#presentational-(inf)">presentationally</a>. These two types of location clauses are <a href="#predicational-location-(inf-cxn)">locative predication</a> and <a href="#presentational-location-(cxn)">presentational locative</a>, respectively. (Section 10.4.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#clause-(cxn)">clause</a> in which a locative relation is expressed, either <a href="#predicational-(inf)">predicationally</a> or <a href="#presentational-(inf)">presentationally</a>. These two types of location clauses are <a href="#predicational-location-(inf)">locative predication</a> and <a href="#presentational-location-(cxn)">presentational locative</a>, respectively. (Section 10.4.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="locational-possessive-strategy-(str)">
@@ -10095,7 +8748,7 @@
 <strong>logophoric construction (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the construction in a <a href="#logophoric-system-(str)">logophoric system</a> for <a href="#complement-clause-construction-(cxn)">complement clause constructions</a> that is used when a <a href="#participant-(sem)">participant</a> in the <a href="#complement-dependent-clause-(cxn)">complement</a> <span class="separation"/> <a href="#event-(sem)">event</a> is <a href="#coreference-(inf)">coreferential</a> with the <u>speaker</u>, <u>addressee</u>, or <a href="#experiencer-(sem)">experiencer</a> of an <a href="#utterance-event-(sem)-predicate-(cxn)">utterance</a>, <a href="#propositional-attitude-event-(sem)-predicate-(cxn)">propositional attitude</a>, <a href="#knowledge-event-(sem)-predicate-(cxn)">knowledge</a>, or <a href="#commentative-event-(sem)">commentative event</a>. <em>Example</em>: Donno Sɔ <em>Oumar Anta inyemɛñ waa be gi</em> <q>Oumar<sub>i</sub> said that Anta had seen him<sub>i</sub></q> is an instance of the logophoric construction – the reference to Oumar in the complement clause uses a special <a href="#pronoun-(cxn)">pronoun</a> form <em>inyemɛñ</em>. (Section 18.4.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the construction in a <a href="#logophoric-system-(str)">logophoric system</a> for <a href="#complement-clause-construction-(cxn)">complement clause constructions</a> that is used when a <a href="#participant-(sem)">participant</a> in the <a href="#complement-dependent-clause-(cxn)">complement</a> <span class="separation"/> <a href="#event-(sem)">event</a> is <a href="#coreference-(inf)">coreferential</a> with the <u>speaker</u>, <u>addressee</u>, or <a href="#experiencer-(sem)">experiencer</a> of an <a href="#utterance-event-(sem)">utterance</a>, <a href="#propositional-attitude-event-(sem)">propositional attitude</a>, <a href="#knowledge-event-(sem)">knowledge</a>, or <a href="#commentative-event-(sem)">commentative event</a>. <em>Example</em>: Donno Sɔ <em>Oumar Anta inyemɛñ waa be gi</em> <q>Oumar<sub>i</sub> said that Anta had seen him<sub>i</sub></q> is an instance of the logophoric construction – the reference to Oumar in the complement clause uses a special <a href="#pronoun-(cxn)">pronoun</a> form <em>inyemɛñ</em>. (Section 18.4.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="logophoric-system-(str)">
@@ -10113,7 +8766,7 @@
 <strong>logophoric system (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#system-(str)">system</a> found with certain <a href="#complement-clause-construction-(cxn)">complement clause constructions</a> where one <a href="#strategy-(def)">strategy</a> is used when a <a href="#participant-(sem)">participant</a> in the <a href="#complement-dependent-clause-(cxn)">complement</a> <span class="separation"/> <a href="#event-(sem)">event</a> is <a href="#coreference-(inf)">coreferential</a> with the <u>speaker</u>, <u>addressee</u>, or <a href="#experiencer-(sem)">experiencer</a> of an <a href="#utterance-event-(sem)-predicate-(cxn)">utterance</a>, <a href="#propositional-attitude-event-(sem)-predicate-(cxn)">propositional attitude</a>, <a href="#knowledge-event-(sem)-predicate-(cxn)">knowledge</a>, or <a href="#commentative-event-(sem)">commentative event</a> (the <a href="#logophoric-construction-(cxn)">logophoric construction</a>), and a different strategy is used when there is no such coreference relation. <em>Example</em>: in Donno Sɔ <em>Oumar Anta inyemɛñ waa be gi</em> <q>Oumar<sub>i</sub> said that Anta had seen him<sub>i</sub></q>, the reference to Oumar in the complement clause uses a special <a href="#pronoun-(cxn)">pronoun</a> form <em>inyemɛñ</em>, but in <em>Oumar Anta woñ waa be gi</em> <q>Oumar<sub>i</sub> said that Anta had seen him<sub>k</sub></q>, the referent in the complement is not Oumar, and so the ordinary <a href="#third-person-pronoun-(cxn)">third person</a> <span class="separation"/> <a href="#anaphoric-pronoun-(cxn)">anaphoric pronoun</a> <em>woñ</em> is used. (Section 18.4.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#system-(str)">system</a> found with certain <a href="#complement-clause-construction-(cxn)">complement clause constructions</a> where one <a href="#strategy-(def)">strategy</a> is used when a <a href="#participant-(sem)">participant</a> in the <a href="#complement-dependent-clause-(cxn)">complement</a> <span class="separation"/> <a href="#event-(sem)">event</a> is <a href="#coreference-(inf)">coreferential</a> with the <u>speaker</u>, <u>addressee</u>, or <a href="#experiencer-(sem)">experiencer</a> of an <a href="#utterance-event-(sem)">utterance</a>, <a href="#propositional-attitude-event-(sem)">propositional attitude</a>, <a href="#knowledge-event-(sem)">knowledge</a>, or <a href="#commentative-event-(sem)">commentative event</a> (the <a href="#logophoric-construction-(cxn)">logophoric construction</a>), and a different strategy is used when there is no such coreference relation. <em>Example</em>: in Donno Sɔ <em>Oumar Anta inyemɛñ waa be gi</em> <q>Oumar<sub>i</sub> said that Anta had seen him<sub>i</sub></q>, the reference to Oumar in the complement clause uses a special <a href="#pronoun-(cxn)">pronoun</a> form <em>inyemɛñ</em>, but in <em>Oumar Anta woñ waa be gi</em> <q>Oumar<sub>i</sub> said that Anta had seen him<sub>k</sub></q>, the referent in the complement is not Oumar, and so the ordinary <a href="#third-person-pronoun-(cxn)">third person</a> <span class="separation"/> <a href="#anaphoric-pronoun-(cxn)">anaphoric pronoun</a> <em>woñ</em> is used. (Section 18.4.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="long-distance-reflexive-(str)">
@@ -10131,7 +8784,7 @@
 <strong>long-distance reflexive (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> in which a <a href="#reflexive-event-(sem)-construction-(cxn)">reflexive</a> <span class="separation"/> <a href="#pronoun-(cxn)">pronoun</a> is used where the <a href="#referring-phrase-(cxn)">referring phrase</a> denoting the referent with which the reflexive pronoun is <a href="#coreference-(inf)">coreferential</a> does not occur in the same <a href="#clause-(cxn)">clause</a> (more or less; the precise definition of <q>local</q> uses of the reflexive pronoun varies). In particular, in the context of this textbook, a reflexive pronoun is used in a <a href="#logophoric-construction-(cxn)">logophoric construction</a>. <em>Example</em>: in Japanese <em>Takasi wa Taroo ni Yosiko ga zibun o nikundeiru koto o hanasita</em> <q>Takasi<sub>i</sub> told Taroo that Yosiko hated him<sub>i</sub></q>, the reflexive pronoun <em>zibun</em> in the <a href="#utterance-event-(sem)-predicate-(cxn)">utterance</a> <span class="separation"/> <a href="#complement-dependent-clause-(cxn)">complement</a> <em>Yosiko ga zibun o nikundeiru koto o</em> is coreferential with the <u>speaker participant</u> <em>Takasi</em> in the <a href="#matrix-clause-(cxn)">matrix clause</a>. It appears that use of a long-distance reflexive in a logophoric construction is part of a larger range of uses of long-distance reflexives, and may not represent a true <a href="#logophoric-system-(str)">logophoric system</a>. (Section 18.4.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> in which a <a href="#reflexive-event-(sem)">reflexive</a> <span class="separation"/> <a href="#pronoun-(cxn)">pronoun</a> is used where the <a href="#referring-phrase-(cxn)">referring phrase</a> denoting the referent with which the reflexive pronoun is <a href="#coreference-(inf)">coreferential</a> does not occur in the same <a href="#clause-(cxn)">clause</a> (more or less; the precise definition of <q>local</q> uses of the reflexive pronoun varies). In particular, in the context of this textbook, a reflexive pronoun is used in a <a href="#logophoric-construction-(cxn)">logophoric construction</a>. <em>Example</em>: in Japanese <em>Takasi wa Taroo ni Yosiko ga zibun o nikundeiru koto o hanasita</em> <q>Takasi<sub>i</sub> told Taroo that Yosiko hated him<sub>i</sub></q>, the reflexive pronoun <em>zibun</em> in the <a href="#utterance-event-(sem)">utterance</a> <span class="separation"/> <a href="#complement-dependent-clause-(cxn)">complement</a> <em>Yosiko ga zibun o nikundeiru koto o</em> is coreferential with the <u>speaker participant</u> <em>Takasi</em> in the <a href="#matrix-clause-(cxn)">matrix clause</a>. It appears that use of a long-distance reflexive in a logophoric construction is part of a larger range of uses of long-distance reflexives, and may not represent a true <a href="#logophoric-system-(str)">logophoric system</a>. (Section 18.4.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="main-clause-(cxn)">
@@ -10194,14 +8847,8 @@
 <div class="cc" id="manipulative-event-(sem)">
 <h2 class="name"><a href="#manipulative-event-(sem)">manipulative event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#manipulative-event-(sem)-predicate-(cxn)">manipulative event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>manipulative event (<i>sem</i>)</strong></span><span><a href="#manipulative-predicate-(cxn)">manipulative predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">manipulative event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">manipulative event | manipulative</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#dependent-time-reference-(sem)">dependent time reference (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -10212,31 +8859,12 @@
 <strong>manipulative event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="manipulative-event-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#manipulative-event-(sem)-predicate-(cxn)">manipulative event (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>manipulative event (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#manipulative-event-(sem)">manipulative event (<i>sem</i>)</a></span><span><a href="#manipulative-predicate-(cxn)">manipulative predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">manipulative event/predicate | manipulative</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> where an <a href="#agent-(sem)">agent</a> acts to bring about the event expressed by the <a href="#complement-dependent-clause-(cxn)">complement</a>; and the <a href="#predicate-(cxn)">predicate</a> expressing such an event. <em>Example</em>: in <em>Bruce convinced Greg to take him to San Rafael, convinced</em> denotes a manipulative event. Manipulative events include causative and permissive events, and manipulative <a href="#complement-clause-construction-(cxn)">complement clause constructions</a> overlap with <a href="#causative-construction-(cxn)">causative constructions</a>. The complement event of manipulative events has <a href="#dependent-time-reference-(sem)">dependent time reference</a>. (Section 18.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> where an <a href="#agent-(sem)">agent</a> acts to bring about the event expressed by the <a href="#complement-dependent-clause-(cxn)">complement</a>. <em>Example</em>: in <em>Bruce convinced Greg to take him to San Rafael, convinced</em> denotes a manipulative event. Manipulative events include causative and permissive events. The complement event of manipulative events has <a href="#dependent-time-reference-(sem)">dependent time reference</a>. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="manipulative-predicate-(cxn)">
 <h2 class="name"><a href="#manipulative-predicate-(cxn)">manipulative predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#manipulative-event-(sem)-predicate-(cxn)">manipulative event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#manipulative-event-(sem)">manipulative event (<i>sem</i>)</a></span><span><strong>manipulative predicate (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">manipulative predicate</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -10248,6 +8876,7 @@
 <strong>manipulative predicate (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#predicate-(cxn)">predicate</a> expressing a <a href="#manipulative-event-(sem)">manipulative event</a>. <em>Example</em>: in <em>Bruce convinced Greg to take him to San Rafael, convinced</em> denotes a manipulative event. Manipulative <a href="#complement-clause-construction-(cxn)">complement clause constructions</a> overlap with <a href="#causative-construction-(cxn)">causative constructions</a>. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="manner-complex-predicate-(cxn)">
@@ -10270,12 +8899,6 @@
 <div class="cc" id="manner-event-(sem)">
 <h2 class="name"><a href="#manner-event-(sem)">manner event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#manner-event-(sem)-verb-(cxn)">manner event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>manner event (<i>sem</i>)</strong></span><span><a href="#manner-verb-(cxn)">manner verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">manner event</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#manner-complex-predicate-(cxn)">manner complex predicate (<i>cxn</i>)</a></td></tr>
@@ -10291,33 +8914,14 @@
 <span><a href="#manner-of-motion-event-(sem)">manner of motion event (<i>sem</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="manner-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#manner-event-(sem)-verb-(cxn)">manner event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>manner event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#manner-event-(sem)">manner event (<i>sem</i>)</a></span><span><a href="#manner-verb-(cxn)">manner verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">manner event/verb | manner</td></tr>
 <tr><th>Definition</th> <td class="ccinfo definition">an event that is described in terms of the manner by which the process progresses (or is brought about by an external cause). <em>Example</em>: in <em>She smeared jam on the toast</em>, the event is described in terms of the manner by which the jam is applied to the toast. (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="manner-of-motion-event-(sem)">
 <h2 class="name"><a href="#manner-of-motion-event-(sem)">manner of motion event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#manner-of-motion-event-(sem)-verb-(cxn)">manner of motion event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>manner of motion event (<i>sem</i>)</strong></span><span><a href="#manner-of-motion-verb-(cxn)">manner of motion verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">manner of motion event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">manner of motion event | manner of motion</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -10328,31 +8932,12 @@
 <strong>manner of motion event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="manner-of-motion-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#manner-of-motion-event-(sem)-verb-(cxn)">manner of motion event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>manner of motion event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#manner-of-motion-event-(sem)">manner of motion event (<i>sem</i>)</a></span><span><a href="#manner-of-motion-verb-(cxn)">manner of motion verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">manner of motion event/verb | manner of motion</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an event that describes motion of a <a href="#figure-(sem)">figure</a> in terms of how the figure travels; and the <a href="#verb-(cxn)">verb</a> expressing such an event. <em>Example</em>: in <em>Sam strode into the room, stride</em> is a manner of motion verb expressing a manner of motion event. (Sections 7.3.1, 14.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an event that describes motion of a <a href="#figure-(sem)">figure</a> in terms of how the figure travels. <em>Example</em>: in <em>Sam strode into the room, stride</em> is a manner of motion verb expressing a manner of motion event. (Sections 7.3.1, 14.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="manner-of-motion-verb-(cxn)">
 <h2 class="name"><a href="#manner-of-motion-verb-(cxn)">manner of motion verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#manner-of-motion-event-(sem)-verb-(cxn)">manner of motion event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#manner-of-motion-event-(sem)">manner of motion event (<i>sem</i>)</a></span><span><strong>manner of motion verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">manner of motion verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -10364,17 +8949,12 @@
 <strong>manner of motion verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing a <a href="#manner-of-motion-event-(sem)">manner of motion event</a>. <em>Example</em>: in <em>Sam strode into the room, stride</em> is a manner of motion verb expressing a manner of motion event. (Sections 7.3.1, 14.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="manner-verb-(cxn)">
 <h2 class="name"><a href="#manner-verb-(cxn)">manner verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#manner-event-(sem)-verb-(cxn)">manner event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#manner-event-(sem)">manner event (<i>sem</i>)</a></span><span><strong>manner verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">manner verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -10394,6 +8974,7 @@
 <span><a href="#removal-verb-(cxn)">removal verb (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#verb-(cxn)">verb</a> expressing a <a href="#manner-event-(sem)">manner event</a>. <em>Example</em>: in <em>She smeared jam on the toast</em>, the event is described in terms of the manner by which the jam is applied to the toast. (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="material-term-(cxn)">
@@ -10631,7 +9212,7 @@
 <strong>middle voice (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> for the <a href="#intransitive-construction-(cxn)">intransitive construction</a> that <a href="#recruitment-strategy-(str)">recruits</a> a <a href="#reflexive-event-(sem)-construction-(cxn)">reflexive</a> or <a href="#reciprocal-construction-(cxn)">reciprocal construction</a>, for the expression of a subset of <a href="#monovalent-event-(sem)">monovalent events</a>. <em>Example</em>: Ancient Greek <em>pete-sthai</em> <q>fly</q> is an example of a middle voice form, using the suffix <em>-sthai</em>. The middle voice construction may be a more <a href="#grammaticalization-(def)">grammaticalized</a> form of the original construction. (Section 7.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> for the <a href="#intransitive-construction-(cxn)">intransitive construction</a> that <a href="#recruitment-strategy-(str)">recruits</a> a <a href="#reflexive-event-(sem)">reflexive</a> or <a href="#reciprocal-construction-(cxn)">reciprocal construction</a>, for the expression of a subset of <a href="#monovalent-event-(sem)">monovalent events</a>. <em>Example</em>: Ancient Greek <em>pete-sthai</em> <q>fly</q> is an example of a middle voice form, using the suffix <em>-sthai</em>. The middle voice construction may be a more <a href="#grammaticalization-(def)">grammaticalized</a> form of the original construction. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="mirative-(sem)">
@@ -10728,7 +9309,7 @@
 <table>
 <tr><th>Type</th> <td class="ccinfo type">def</td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">modification–predication continuum</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a continuum of <a href="#information-packaging-(def)">information packaging</a> functions from prototypical <a href="#modification-(inf)">modification</a> – that is, <a href="#restrictive-modification-(inf)">restrictive modification</a> – to prototypical <a href="#predication-(inf)">predication</a>. The intermediate functions in this continuum are identified as (roughly, from most modifier-like to most predicate-like) <a href="#appositive-modification-(inf)">appositive</a>, <a href="#complementative-(inf)">complementative</a>, <a href="#depictive-complex-predicate-(cxn)">depictive</a>, <a href="#resultative-complex-predicate-(cxn)">resultative</a>, and <a href="#manner-event-(sem)-verb-(cxn)">manner</a>. (Section 14.3)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a continuum of <a href="#information-packaging-(def)">information packaging</a> functions from prototypical <a href="#modification-(inf)">modification</a> – that is, <a href="#restrictive-modification-(inf)">restrictive modification</a> – to prototypical <a href="#predication-(inf)">predication</a>. The intermediate functions in this continuum are identified as (roughly, from most modifier-like to most predicate-like) <a href="#appositive-modification-(inf)">appositive</a>, <a href="#complementative-(inf)">complementative</a>, <a href="#depictive-complex-predicate-(cxn)">depictive</a>, <a href="#resultative-complex-predicate-(cxn)">resultative</a>, and <a href="#manner-complex-predicate-(cxn)">manner</a>. (Section 14.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="modification-reference-continuum-(def)">
@@ -10844,14 +9425,8 @@
 <div class="cc" id="motion-event-(sem)">
 <h2 class="name"><a href="#motion-event-(sem)">motion event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#motion-event-(sem)-verb-(cxn)">motion event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>motion event (<i>sem</i>)</strong></span><span><a href="#motion-verb-(cxn)">motion verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">motion event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">motion event | motion</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#middle-voice-(str)">middle voice (<i>str</i>)</a> | <a href="#ground-(sem)">ground (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -10866,31 +9441,12 @@
 <span><a href="#path-of-motion-event-(sem)">path (of motion) event (<i>sem</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="motion-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#motion-event-(sem)-verb-(cxn)">motion event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>motion event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#motion-event-(sem)">motion event (<i>sem</i>)</a></span><span><a href="#motion-verb-(cxn)">motion verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">motion event/verb | motion</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#monovalent-event-(sem)">monovalent event</a> involving motion of a <a href="#participant-(sem)">participant</a> from one place to another (translational motion); and the <a href="#verb-(cxn)">verb</a> expressing that event. <em>Examples</em>: <em>fly</em> and <em>go</em> express motion events. Motion events contrast with <a href="#bodily-motion-event-(sem)">bodily motion events</a>: motion events involve movement from one location to another, whereas bodily motion events involve internal motion of a body part. Motion events may express <a href="#path-of-motion-event-(sem)-verb-(cxn)">path of motion</a> or <a href="#manner-of-motion-event-(sem)-verb-(cxn)">manner of motion</a>, or both. Motion events may be divided into <a href="#departure-(sem)">departure</a>, <a href="#passing-(sem)">passing</a>, and <a href="#arrival-(sem)">arrival</a> phases of the path of motion. (Sections 7.2, 7.3.1, 14.4)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#monovalent-event-(sem)">monovalent event</a> involving motion of a <a href="#participant-(sem)">participant</a> from one place to another (translational motion). <em>Examples</em>: <em>fly</em> and <em>go</em> express motion events. Motion events contrast with <a href="#bodily-motion-event-(sem)">bodily motion events</a>: motion events involve movement from one location to another, whereas bodily motion events involve internal motion of a body part. Motion events may express <a href="#path-of-motion-event-(sem)">path of motion</a> or <a href="#manner-of-motion-event-(sem)">manner of motion</a>, or both. Motion events may be divided into <a href="#departure-(sem)">departure</a>, <a href="#passing-(sem)">passing</a>, and <a href="#arrival-(sem)">arrival</a> phases of the path of motion. (Sections 7.2, 7.3.1, 14.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="motion-verb-(cxn)">
 <h2 class="name"><a href="#motion-verb-(cxn)">motion verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#motion-event-(sem)-verb-(cxn)">motion event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#motion-event-(sem)">motion event (<i>sem</i>)</a></span><span><strong>motion verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">motion verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -10902,6 +9458,7 @@
 <strong>motion verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing a <a href="#motion-event-(sem)">motion event</a>. <em>Examples</em>: <em>fly</em> and <em>go</em> express motion events. (Sections 7.2, 7.3.1, 14.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="necessary-participant-sharing-(sem)">
@@ -11364,12 +9921,6 @@
 <div class="cc" id="nonspecific-article-(cxn)">
 <h2 class="name"><a href="#nonspecific-article-(cxn)">nonspecific article (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#nonspecific-referent-(inf)-article-(cxn)-pronoun-(cxn)">nonspecific referent (<i>inf</i>) / article (<i>cxn</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>nonspecific article (<i>cxn</i>)</strong></span><span><a href="#nonspecific-pronoun-(cxn)">nonspecific pronoun (<i>cxn</i>)</a></span><span><a href="#nonspecific-referent-(inf)">nonspecific referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">nonspecific article</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -11381,17 +9932,12 @@
 <strong>nonspecific article (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#article-(cxn)">article</a> that is used for a <a href="#nonspecific-referent-(inf)">nonspecific referent</a>. (Section 3.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="nonspecific-pronoun-(cxn)">
 <h2 class="name"><a href="#nonspecific-pronoun-(cxn)">nonspecific pronoun (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#nonspecific-referent-(inf)-article-(cxn)-pronoun-(cxn)">nonspecific referent (<i>inf</i>) / article (<i>cxn</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#nonspecific-article-(cxn)">nonspecific article (<i>cxn</i>)</a></span><span><strong>nonspecific pronoun (<i>cxn</i>)</strong></span><span><a href="#nonspecific-referent-(inf)">nonspecific referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">nonspecific pronoun</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -11403,17 +9949,12 @@
 <strong>nonspecific pronoun (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#pronoun-(cxn)">pronoun</a> that expresses a <a href="#nonspecific-referent-(inf)">nonspecific referent</a>. (Section 3.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="nonspecific-referent-(inf)">
 <h2 class="name"><a href="#nonspecific-referent-(inf)">nonspecific referent (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#nonspecific-referent-(inf)-article-(cxn)-pronoun-(cxn)">nonspecific referent (<i>inf</i>) / article (<i>cxn</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#nonspecific-article-(cxn)">nonspecific article (<i>cxn</i>)</a></span><span><a href="#nonspecific-pronoun-(cxn)">nonspecific pronoun (<i>cxn</i>)</a></span><span><strong>nonspecific referent (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">nonspecific referent</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -11434,19 +9975,6 @@
 <span><a href="#question-referent-(inf)">question referent (<i>inf</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="nonspecific-referent-(inf)-article-(cxn)-pronoun-(cxn)">
-<h2 class="name"><a href="#nonspecific-referent-(inf)-article-(cxn)-pronoun-(cxn)">nonspecific referent (<i>inf</i>) / article (<i>cxn</i>) / pronoun (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>nonspecific referent (<i>inf</i>) / article (<i>cxn</i>) / pronoun (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#nonspecific-article-(cxn)">nonspecific article (<i>cxn</i>)</a></span><span><a href="#nonspecific-pronoun-(cxn)">nonspecific pronoun (<i>cxn</i>)</a></span><span><a href="#nonspecific-referent-(inf)">nonspecific referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">nonspecific referent/article/pronoun | nonspecific</td></tr>
 <tr><th>Definition</th> <td class="ccinfo definition">the information status of a referent whose identity cannot be known to the speaker and the hearer because the referent is only <a href="#type-identifiable-(inf)">type identifiable</a>. <em>Example</em>: in <em>A student came to my office</em>, the hearer does not know the identity of the student, and hence that referent is nonspecific. (Section 3.5)</td></tr>
 </table>
 </div>
@@ -11854,7 +10382,7 @@
 <strong>ordered strategy (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#strategy-(def)">strategy</a> for <a href="#comparative-referent-(inf)-pronoun-(cxn)">comparative</a> (and possibly <a href="#equative-construction-(cxn)">equative</a>) <a href="#construction-(def)">constructions</a> which metaphorically expresses the comparison of the <a href="#comparee-(sem)">comparee</a> and the <a href="#standard-(sem)">standard</a> on the <a href="#gradable-predicative-scale-(sem)">gradable predicative scale</a> as a spatial <a href="#path-of-motion-event-(sem)-verb-(cxn)">path</a> between the comparee (as spatial <a href="#figure-(sem)">figure</a>) and the standard (as the <a href="#ground-(sem)">ground</a>). In comparative constructions, the ordered strategy <a href="#recruitment-strategy-(str)">recruits</a> a <a href="#different-subject-(inf)">different-subject</a>, <a href="#absolute-deranking-system-(str)">absolutely deranked</a>, <a href="#simultaneous-(sem)">simultaneous</a>, or <a href="#consecutive-(sem)">consecutive</a> <u>temporal</u> <a href="#complex-sentence-(cxn)">complex sentence construction</a> to express comparison. The <a href="#separative-comparative-(str)">separative</a>, <a href="#allative-comparative-(str)">allative</a>, and <a href="#locative-comparative-(str)">locative comparatives</a> are examples of the ordered strategy. (Section 17.2.3)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#strategy-(def)">strategy</a> for <a href="#comparative-construction-(cxn)">comparative</a> (and possibly <a href="#equative-construction-(cxn)">equative</a>) <a href="#construction-(def)">constructions</a> which metaphorically expresses the comparison of the <a href="#comparee-(sem)">comparee</a> and the <a href="#standard-(sem)">standard</a> on the <a href="#gradable-predicative-scale-(sem)">gradable predicative scale</a> as a spatial <a href="#path-of-motion-event-(sem)">path</a> between the comparee (as spatial <a href="#figure-(sem)">figure</a>) and the standard (as the <a href="#ground-(sem)">ground</a>). In comparative constructions, the ordered strategy <a href="#recruitment-strategy-(str)">recruits</a> a <a href="#different-subject-(inf)">different-subject</a>, <a href="#absolute-deranking-system-(str)">absolutely deranked</a>, <a href="#simultaneous-(sem)">simultaneous</a>, or <a href="#consecutive-(sem)">consecutive</a> <u>temporal</u> <a href="#complex-sentence-(cxn)">complex sentence construction</a> to express comparison. The <a href="#separative-comparative-(str)">separative</a>, <a href="#allative-comparative-(str)">allative</a>, and <a href="#locative-comparative-(str)">locative comparatives</a> are examples of the ordered strategy. (Section 17.2.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="ordinal-numeral-(cxn)">
@@ -12141,7 +10669,7 @@
 <strong>participial strategy (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-event-(sem)-verb-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is packaged as a separate primary <a href="#predication-(inf)">predication</a> <span class="separation"/> <a href="#coordinate-construction-(cxn)">coordinated</a> with the <a href="#event-(sem)">event</a> predication using a <a href="#deranked,-deranking-(str)">deranked</a> <span class="separation"/> <a href="#complex-sentence-(cxn)">complex sentence</a> <span class="separation"/> <a href="#strategy-(def)">strategy</a>. In addition, the stative predicate is predicated of, and ideally <a href="#index-(str)">indexes</a>, (one of) its argument(s). <em>Example</em>: in Sanuma <em>opi-i a kali-palo-ma</em> <q>He worked slowly</q> [lit. <q>being slow, he worked</q>] <em>opi-i</em> <q>be slow</q> is in a deranked form with suffix <em>-i</em>; the suffix, however, indicates that <em>opi</em> <q>slow</q> has the same subject as <em>kali-palo-ma</em> <q>worked</q> – namely, <q>he</q>. (Section 14.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-complex-predicate-(cxn)">manner</a> (more generally, <a href="#stative-(sem)">stative</a>) <u>component</u> is packaged as a separate primary <a href="#predication-(inf)">predication</a> <span class="separation"/> <a href="#coordinate-construction-(cxn)">coordinated</a> with the <a href="#event-(sem)">event</a> predication using a <a href="#deranked,-deranking-(str)">deranked</a> <span class="separation"/> <a href="#complex-sentence-(cxn)">complex sentence</a> <span class="separation"/> <a href="#strategy-(def)">strategy</a>. In addition, the stative predicate is predicated of, and ideally <a href="#index-(str)">indexes</a>, (one of) its argument(s). <em>Example</em>: in Sanuma <em>opi-i a kali-palo-ma</em> <q>He worked slowly</q> [lit. <q>being slow, he worked</q>] <em>opi-i</em> <q>be slow</q> is in a deranked form with suffix <em>-i</em>; the suffix, however, indicates that <em>opi</em> <q>slow</q> has the same subject as <em>kali-palo-ma</em> <q>worked</q> – namely, <q>he</q>. (Section 14.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="participle-(str)">
@@ -12178,7 +10706,7 @@
 <strong>particle comparative (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#derived-case-(str)">derived-case</a> <span class="separation"/> <a href="#comparative-referent-(inf)-pronoun-(cxn)">comparative</a> <span class="separation"/> <a href="#strategy-(def)">strategy</a> that consists of two <a href="#clause-(cxn)">clauses</a> which assert that the <a href="#gradable-predicative-scale-(sem)">gradable predicative scale</a> applies to the <a href="#comparee-(sem)">comparee</a> and the <a href="#standard-(sem)">standard</a>, but the second clause uses the <a href="#zero-strategy-(str)">zero strategy</a> for <a href="#predicate-identity-(cxn)">predicate identity</a>, and the <a href="#conjunction-(str)">conjunction</a> is a particle with diverse etymological origins. <em>Example</em>: <em>Randy is older than Tom (is)</em> is an instance of the particle strategy: the clause <em>Randy is older</em> is followed by the particle <em>than</em> which introduces the standard phrase <em>Tom</em> without its own <a href="#predicate-(cxn)">predicate</a> (only an optional auxiliary <em>is</em>). (Section 17.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#derived-case-(str)">derived-case</a> <span class="separation"/> <a href="#comparative-construction-(cxn)">comparative</a> <span class="separation"/> <a href="#strategy-(def)">strategy</a> that consists of two <a href="#clause-(cxn)">clauses</a> which assert that the <a href="#gradable-predicative-scale-(sem)">gradable predicative scale</a> applies to the <a href="#comparee-(sem)">comparee</a> and the <a href="#standard-(sem)">standard</a>, but the second clause uses the <a href="#zero-strategy-(str)">zero strategy</a> for <a href="#predicate-identity-(cxn)">predicate identity</a>, and the <a href="#conjunction-(str)">conjunction</a> is a particle with diverse etymological origins. <em>Example</em>: <em>Randy is older than Tom (is)</em> is an instance of the particle strategy: the clause <em>Randy is older</em> is followed by the particle <em>than</em> which introduces the standard phrase <em>Tom</em> without its own <a href="#predicate-(cxn)">predicate</a> (only an optional auxiliary <em>is</em>). (Section 17.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="particle-equative-(str)">
@@ -12238,7 +10766,7 @@
 <strong>passing (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the intermediate phase of the <a href="#path-of-motion-event-(sem)-verb-(cxn)">path</a> in a <a href="#motion-event-(sem)">motion event</a>. <em>Example</em>: in the Lao <a href="#serial-verb-strategy-(str)">serial verb</a> <span class="separation"/> <a href="#construction-(def)">construction</a> <em>man<sup>2</sup> lèèn<sup>1</sup> qòòk<sup>5</sup> caak<sup>5</sup> hùan<sup>2</sup> taam<sup>3</sup> thaang<sup>2</sup> hòòt<sup>4</sup> kòòn<sup>4</sup>-hiin<sup>3</sup></em> <q>He ran (exited) from the house, followed the path, reached the rock</q>, <em>taam<sup>3</sup></em> <q>follow</q> denotes the passing phase of the motion event. (Section 14.4)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the intermediate phase of the <a href="#path-of-motion-event-(sem)">path</a> in a <a href="#motion-event-(sem)">motion event</a>. <em>Example</em>: in the Lao <a href="#serial-verb-strategy-(str)">serial verb</a> <span class="separation"/> <a href="#construction-(def)">construction</a> <em>man<sup>2</sup> lèèn<sup>1</sup> qòòk<sup>5</sup> caak<sup>5</sup> hùan<sup>2</sup> taam<sup>3</sup> thaang<sup>2</sup> hòòt<sup>4</sup> kòòn<sup>4</sup>-hiin<sup>3</sup></em> <q>He ran (exited) from the house, followed the path, reached the rock</q>, <em>taam<sup>3</sup></em> <q>follow</q> denotes the passing phase of the motion event. (Section 14.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="passive-inverse-voice-construction-(cxn)">
@@ -12261,14 +10789,8 @@
 <div class="cc" id="path-of-motion-event-(sem)">
 <h2 class="name"><a href="#path-of-motion-event-(sem)">path (of motion) event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#path-of-motion-event-(sem)-verb-(cxn)">path (of motion) event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>path (of motion) event (<i>sem</i>)</strong></span><span><a href="#path-of-motion-verb-(cxn)">path (of motion) verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">path (of motion) event | path of motion event | path event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">path (of motion) event | path of motion event | path of motion | path event | path</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -12283,31 +10805,12 @@
 <span><a href="#passing-(sem)">passing (<i>sem</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="path-of-motion-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#path-of-motion-event-(sem)-verb-(cxn)">path (of motion) event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>path (of motion) event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#path-of-motion-event-(sem)">path (of motion) event (<i>sem</i>)</a></span><span><a href="#path-of-motion-verb-(cxn)">path (of motion) verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">path (of motion) event/verb | path (of motion) | path of motion event/verb | path of motion | path event/verb | path</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an event that describes motion of a <a href="#figure-(sem)">figure</a> along a spatial path relative to a <a href="#ground-(sem)">ground</a>; and the <a href="#verb-(cxn)">verb</a> expressing such an event. <em>Example</em>: in <em>The guests entered the reception hall, enter</em> is a path of motion verb expressing a path of motion event. (Sections 7.3.1, 14.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an event that describes motion of a <a href="#figure-(sem)">figure</a> along a spatial path relative to a <a href="#ground-(sem)">ground</a>. <em>Example</em>: in <em>The guests entered the reception hall, enter</em> is a path of motion verb expressing a path of motion event. (Sections 7.3.1, 14.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="path-of-motion-verb-(cxn)">
 <h2 class="name"><a href="#path-of-motion-verb-(cxn)">path (of motion) verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#path-of-motion-event-(sem)-verb-(cxn)">path (of motion) event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#path-of-motion-event-(sem)">path (of motion) event (<i>sem</i>)</a></span><span><strong>path (of motion) verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">path (of motion) verb | path of motion verb | path verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -12319,6 +10822,7 @@
 <strong>path (of motion) verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing such a <a href="#path-of-motion-event-(sem)">path of motion event</a>. <em>Example</em>: in <em>The guests entered the reception hall, enter</em> is a path of motion verb expressing a path of motion event. (Sections 7.3.1, 14.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="patient-(sem)">
@@ -12341,14 +10845,9 @@
 <div class="cc" id="perception-complement-taking-predicate-(cxn)">
 <h2 class="name"><a href="#perception-complement-taking-predicate-(cxn)">perception complement-taking predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#perception-event-(sem)-verb-(cxn)-complement-taking-predicate-(cxn)">perception event (<i>sem</i>) / verb (<i>cxn</i>) / complement-taking predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>perception complement-taking predicate (<i>cxn</i>)</strong></span><span><a href="#perception-event-(sem)">perception event (<i>sem</i>)</a></span><span><a href="#perception-verb-(cxn)">perception verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">perception complement-taking predicate</td></tr>
+<tr><th>Associated</th> <td class="ccinfo relation"><a href="#perception-event-(sem)">perception event (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -12358,19 +10857,14 @@
 <strong>perception complement-taking predicate (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">A perception complement-taking predicate is a <a href="#predicate-(cxn)">predicate</a> that expresses perceiving an event, which is expressed as the <a href="#complement-dependent-clause-(cxn)">complement</a> event of the predicate. <em>Example</em>: in <em>We watched the elk graze in the caldera</em>, watched denotes a perception event. The complement event has <a href="#dependent-time-reference-(sem)">dependent time reference</a>; the complement event must be occurring at the same time as the perceiving event (although modern media allowing watching a prior event via a recording). (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="perception-event-(sem)">
 <h2 class="name"><a href="#perception-event-(sem)">perception event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#perception-event-(sem)-verb-(cxn)-complement-taking-predicate-(cxn)">perception event (<i>sem</i>) / verb (<i>cxn</i>) / complement-taking predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#perception-complement-taking-predicate-(cxn)">perception complement-taking predicate (<i>cxn</i>)</a></span><span><strong>perception event (<i>sem</i>)</strong></span><span><a href="#perception-verb-(cxn)">perception verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">perception event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">perception event | perception</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#dependent-time-reference-(sem)">dependent time reference (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -12381,33 +10875,15 @@
 <strong>perception event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="perception-event-(sem)-verb-(cxn)-complement-taking-predicate-(cxn)">
-<h2 class="name"><a href="#perception-event-(sem)-verb-(cxn)-complement-taking-predicate-(cxn)">perception event (<i>sem</i>) / verb (<i>cxn</i>) / complement-taking predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>perception event (<i>sem</i>) / verb (<i>cxn</i>) / complement-taking predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#perception-complement-taking-predicate-(cxn)">perception complement-taking predicate (<i>cxn</i>)</a></span><span><a href="#perception-event-(sem)">perception event (<i>sem</i>)</a></span><span><a href="#perception-verb-(cxn)">perception verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">perception event/verb/complement-taking predicate | perception</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#experiential-event-(sem)">experiential event</a> involving one (or more) of the sensory modalities and directed toward a <a href="#stimulus-(sem)">stimulus</a>. The stimulus may be either an <a href="#object-phrase-(cxn)">object</a> or an <a href="#event-(sem)">event</a>. A perception verb is a <a href="#verb-(cxn)">verb</a> that expresses the event of perceiving an object. <em>Example</em>: <em>Tim heard the macaw</em> is an example of a perception event, and <em>hear</em> is the perception verb (Section 7.4). A perception complement-taking predicate is a <a href="#predicate-(cxn)">predicate</a> that expresses perceiving an event, which is expressed as the <a href="#complement-dependent-clause-(cxn)">complement</a> event of the predicate. <em>Example</em>: in <em>We watched the elk graze in the caldera</em>, watched denotes a perception event. The complement event has <a href="#dependent-time-reference-(sem)">dependent time reference</a>; the complement event must be occurring at the same time as the perceiving event (although modern media allowing watching a prior event via a recording). (Section 18.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#experiential-event-(sem)">experiential event</a> involving one (or more) of the sensory modalities and directed toward a <a href="#stimulus-(sem)">stimulus</a>. The stimulus may be either an <a href="#object-phrase-(cxn)">object</a> or an <a href="#event-(sem)">event</a>. <em>Example</em>: <em>Tim heard the macaw</em> is an example of a perception event, and <em>hear</em> is the perception verb (Section 7.4).</td></tr>
 </table>
 </div>
 <div class="cc" id="perception-verb-(cxn)">
 <h2 class="name"><a href="#perception-verb-(cxn)">perception verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#perception-event-(sem)-verb-(cxn)-complement-taking-predicate-(cxn)">perception event (<i>sem</i>) / verb (<i>cxn</i>) / complement-taking predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#perception-complement-taking-predicate-(cxn)">perception complement-taking predicate (<i>cxn</i>)</a></span><span><a href="#perception-event-(sem)">perception event (<i>sem</i>)</a></span><span><strong>perception verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">perception verb</td></tr>
+<tr><th>Associated</th> <td class="ccinfo relation"><a href="#perception-event-(sem)">perception event (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -12417,6 +10893,7 @@
 <strong>perception verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a perception verb is a <a href="#verb-(cxn)">verb</a> that expresses the event of perceiving an object. <em>Example</em>: <em>Tim heard the macaw</em> is an example of a perception event, and <em>hear</em> is the perception verb (Section 7.4).</td></tr>
 </table>
 </div>
 <div class="cc" id="perception-verb-strategy-(str)">
@@ -12663,14 +11140,8 @@
 <div class="cc" id="polarity-question-(cxn)">
 <h2 class="name"><a href="#polarity-question-(cxn)">polarity question (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#polarity-question-(inf-cxn)">polarity question (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>polarity question (<i>cxn</i>)</strong></span><span><a href="#polarity-question-(inf)">polarity question (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">polarity question</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">polarity question | yes/no question | Y/N question</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -12680,33 +11151,14 @@
 <strong>polarity question (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="polarity-question-(inf-cxn)">
-<h2 class="name"><a href="#polarity-question-(inf-cxn)">polarity question (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>polarity question (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#polarity-question-(cxn)">polarity question (<i>cxn</i>)</a></span><span><a href="#polarity-question-(inf)">polarity question (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">polarity question | yes/no question | Y/N question</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#interrogative-(inf)">interrogative</a> in which the unknown piece of the <a href="#propositional-content-(sem)">propositional content</a> requested of the addressee is the <a href="#polarity-(sem)">polarity</a> (<a href="#positive-polarity-(sem)">positive</a> or <a href="#negative-polarity-(sem)">negative</a>) of the proposition; and the <a href="#construction-(def)">construction</a> expressing this function. <em>Example</em>: <em>Are you coming?</em> is an instance of the English polarity question construction, expecting a <q>yes</q> or <q>no</q> answer. (Section 12.3.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> expressing the <a href="#polarity-question-(inf)">polarity question function</a>. <em>Example</em>: <em>Are you coming?</em> is an instance of the English polarity question construction, expecting a <q>yes</q> or <q>no</q> answer. (Section 12.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="polarity-question-(inf)">
 <h2 class="name"><a href="#polarity-question-(inf)">polarity question (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#polarity-question-(inf-cxn)">polarity question (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#polarity-question-(cxn)">polarity question (<i>cxn</i>)</a></span><span><strong>polarity question (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">polarity question</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">polarity question | polarity question function</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -12716,19 +11168,14 @@
 <strong>polarity question (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#interrogative-(inf)">interrogative</a> in which the unknown piece of the <a href="#propositional-content-(sem)">propositional content</a> requested of the addressee is the <a href="#polarity-(sem)">polarity</a> (<a href="#positive-polarity-(sem)">positive</a> or <a href="#negative-polarity-(sem)">negative</a>) of the proposition. (Section 12.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="polarity-response-(cxn)">
 <h2 class="name"><a href="#polarity-response-(cxn)">polarity response (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#polarity-response-(inf-cxn)">polarity response (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>polarity response (<i>cxn</i>)</strong></span><span><a href="#polarity-response-(inf)">polarity response (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">polarity response</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">polarity response | polarity answer</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#polarity-question-(cxn)">polarity question (<i>cxn</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -12739,33 +11186,14 @@
 <strong>polarity response (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="polarity-response-(inf-cxn)">
-<h2 class="name"><a href="#polarity-response-(inf-cxn)">polarity response (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>polarity response (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#polarity-response-(cxn)">polarity response (<i>cxn</i>)</a></span><span><a href="#polarity-response-(inf)">polarity response (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">polarity response</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the <u>answer</u> to a <a href="#polarity-question-(inf)">polarity question</a>, and the <a href="#construction-(def)">construction</a> that expresses that answer. <em>Example</em>: the polarity response to <em>Do you have any money?</em> in English is <em>Yes (I do)</em> or <em>No (I don't)</em>. (This is excluding other less cooperative responses such as <em>I don't know</em> or <em>It's none of your business</em>.) (Section 12.3.3)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> that expresses a <a href="#polarity-response-(inf)">polarity answer</a>. <em>Example</em>: the polarity response to <em>Do you have any money?</em> in English is <em>Yes (I do)</em> or <em>No (I don't)</em>. (This is excluding other less cooperative responses such as <em>I don't know</em> or <em>It's none of your business</em>.) (Section 12.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="polarity-response-(inf)">
 <h2 class="name"><a href="#polarity-response-(inf)">polarity response (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#polarity-response-(inf-cxn)">polarity response (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#polarity-response-(cxn)">polarity response (<i>cxn</i>)</a></span><span><strong>polarity response (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">polarity response</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">polarity response | polarity answer</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#polarity-question-(inf)">polarity question (<i>inf</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -12776,6 +11204,7 @@
 <strong>polarity response (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <u>answer</u> to a <a href="#polarity-question-(inf)">polarity question</a>. <em>Example</em>: the polarity response to <em>Do you have any money?</em> in English is <em>Yes (I do)</em> or <em>No (I don't)</em>. (This is excluding other less cooperative responses such as <em>I don't know</em> or <em>It's none of your business</em>.) (Section 12.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="poset-(inf)">
@@ -13078,12 +11507,6 @@
 <div class="cc" id="pragmatically-nonspecific-but-semantically-specific-indefinite-article-(cxn)">
 <h2 class="name"><a href="#pragmatically-nonspecific-but-semantically-specific-indefinite-article-(cxn)">pragmatically nonspecific (but semantically specific) (indefinite) article (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#pragmatically-nonspecific-but-semantically-specific-indefinite-referent-(inf)-article-(cxn)">pragmatically nonspecific (but semantically specific) (indefinite) referent (<i>inf</i>) / article (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>pragmatically nonspecific (but semantically specific) (indefinite) article (<i>cxn</i>)</strong></span><span><a href="#pragmatically-nonspecific-but-semantically-specific-indefinite-referent-(inf)">pragmatically nonspecific (but semantically specific) (indefinite) referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">pragmatically nonspecific (but semantically specific) (indefinite) article | pragmatically nonspecific (but semantically specific) indefinite article | pragmatically nonspecific (but semantically specific) article | pragmatically nonspecific but semantically specific (indefinite) article | pragmatically nonspecific but semantically specific indefinite article | pragmatically nonspecific but semantically specific article | pragmatically nonspecific (indefinite) article | pragmatically nonspecific indefinite article | pragmatically nonspecific article</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -13095,19 +11518,14 @@
 <strong>pragmatically nonspecific (but semantically specific) (indefinite) article (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#article-(cxn)">article</a> that is used for a <a href="#pragmatically-nonspecific-but-semantically-specific-indefinite-referent-(inf)">pragmatically nonspecific (but semantically specific) indefinite referent</a>. (Section 3.4.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="pragmatically-nonspecific-but-semantically-specific-indefinite-referent-(inf)">
 <h2 class="name"><a href="#pragmatically-nonspecific-but-semantically-specific-indefinite-referent-(inf)">pragmatically nonspecific (but semantically specific) (indefinite) referent (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#pragmatically-nonspecific-but-semantically-specific-indefinite-referent-(inf)-article-(cxn)">pragmatically nonspecific (but semantically specific) (indefinite) referent (<i>inf</i>) / article (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#pragmatically-nonspecific-but-semantically-specific-indefinite-article-(cxn)">pragmatically nonspecific (but semantically specific) (indefinite) article (<i>cxn</i>)</a></span><span><strong>pragmatically nonspecific (but semantically specific) (indefinite) referent (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">pragmatically nonspecific (but semantically specific) (indefinite) referent | pragmatically nonspecific (but semantically specific) indefinite referent | pragmatically nonspecific (but semantically specific) referent | pragmatically nonspecific but semantically specific (indefinite) referent | pragmatically nonspecific but semantically specific indefinite referent | pragmatically nonspecific but semantically specific referent | pragmatically nonspecific (indefinite) referent | pragmatically nonspecific indefinite referent | pragmatically nonspecific referent</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">pragmatically nonspecific (but semantically specific) (indefinite) referent | pragmatically nonspecific (but semantically specific) indefinite referent | pragmatically nonspecific (but semantically specific) referent | pragmatically nonspecific (but semantically specific) | pragmatically nonspecific but semantically specific (indefinite) referent | pragmatically nonspecific but semantically specific indefinite referent | pragmatically nonspecific but semantically specific referent | pragmatically nonspecific (indefinite) referent | pragmatically nonspecific indefinite referent | pragmatically nonspecific referent</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -13117,31 +11535,12 @@
 <strong>pragmatically nonspecific (but semantically specific) (indefinite) referent (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="pragmatically-nonspecific-but-semantically-specific-indefinite-referent-(inf)-article-(cxn)">
-<h2 class="name"><a href="#pragmatically-nonspecific-but-semantically-specific-indefinite-referent-(inf)-article-(cxn)">pragmatically nonspecific (but semantically specific) (indefinite) referent (<i>inf</i>) / article (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>pragmatically nonspecific (but semantically specific) (indefinite) referent (<i>inf</i>) / article (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#pragmatically-nonspecific-but-semantically-specific-indefinite-article-(cxn)">pragmatically nonspecific (but semantically specific) (indefinite) article (<i>cxn</i>)</a></span><span><a href="#pragmatically-nonspecific-but-semantically-specific-indefinite-referent-(inf)">pragmatically nonspecific (but semantically specific) (indefinite) referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">pragmatically nonspecific (but semantically specific) (indefinite) referent/article | pragmatically nonspecific (but semantically specific) (indefinite) | pragmatically nonspecific (but semantically specific) indefinite referent/article | pragmatically nonspecific (but semantically specific) indefinite | pragmatically nonspecific (but semantically specific) referent/article | pragmatically nonspecific (but semantically specific) | pragmatically nonspecific but semantically specific (indefinite) referent/article | pragmatically nonspecific but semantically specific (indefinite) | pragmatically nonspecific but semantically specific indefinite referent/article | pragmatically nonspecific but semantically specific indefinite | pragmatically nonspecific but semantically specific referent/article | pragmatically nonspecific but semantically specific | pragmatically nonspecific (indefinite) referent/article | pragmatically nonspecific (indefinite) | pragmatically nonspecific indefinite referent/article | pragmatically nonspecific indefinite | pragmatically nonspecific referent/article | pragmatically nonspecific | semantically specific</td></tr>
 <tr><th>Definition</th> <td class="ccinfo definition">a <a href="#reference,-referent-(inf)">referent</a> introduced into the discourse by the speaker that is not normally referred to again in subsequent discourse. The term <q>semantically specific</q> indicates that the referent is not in a nonreal context – that is, it is not a nonspecific referent. We will use the shorter term <q>pragmatically nonspecific</q> and assume that such referents are also semantically specific. (Section 3.4.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="pragmatically-specific-indefinite-article-(cxn)">
 <h2 class="name"><a href="#pragmatically-specific-indefinite-article-(cxn)">pragmatically specific (indefinite) article (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#pragmatically-specific-indefinite-referent-(inf)-article-(cxn)">pragmatically specific (indefinite) referent (<i>inf</i>) / article (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>pragmatically specific (indefinite) article (<i>cxn</i>)</strong></span><span><a href="#pragmatically-specific-indefinite-referent-(inf)">pragmatically specific (indefinite) referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">pragmatically specific (indefinite) article | pragmatically specific indefinite article | pragmatically specific article</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -13153,19 +11552,14 @@
 <strong>pragmatically specific (indefinite) article (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#article-(cxn)">article</a> that is used for a <a href="#pragmatically-specific-indefinite-referent-(inf)">pragmatically specific referent</a>. (Section 3.4.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="pragmatically-specific-indefinite-referent-(inf)">
 <h2 class="name"><a href="#pragmatically-specific-indefinite-referent-(inf)">pragmatically specific (indefinite) referent (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#pragmatically-specific-indefinite-referent-(inf)-article-(cxn)">pragmatically specific (indefinite) referent (<i>inf</i>) / article (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#pragmatically-specific-indefinite-article-(cxn)">pragmatically specific (indefinite) article (<i>cxn</i>)</a></span><span><strong>pragmatically specific (indefinite) referent (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">pragmatically specific (indefinite) referent | pragmatically specific indefinite referent | pragmatically specific referent</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">pragmatically specific (indefinite) referent | pragmatically specific indefinite referent | pragmatically specific referent | pragmatically specific</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -13175,19 +11569,6 @@
 <strong>pragmatically specific (indefinite) referent (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="pragmatically-specific-indefinite-referent-(inf)-article-(cxn)">
-<h2 class="name"><a href="#pragmatically-specific-indefinite-referent-(inf)-article-(cxn)">pragmatically specific (indefinite) referent (<i>inf</i>) / article (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>pragmatically specific (indefinite) referent (<i>inf</i>) / article (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#pragmatically-specific-indefinite-article-(cxn)">pragmatically specific (indefinite) article (<i>cxn</i>)</a></span><span><a href="#pragmatically-specific-indefinite-referent-(inf)">pragmatically specific (indefinite) referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">pragmatically specific (indefinite) referent/article | pragmatically specific (indefinite) | pragmatically specific indefinite referent/article | pragmatically specific indefinite | pragmatically specific referent/article | pragmatically specific</td></tr>
 <tr><th>Definition</th> <td class="ccinfo definition">a referent introduced into the discourse by the speaker that is normally referred to again in subsequent discourse. We will use the shorter term <q>pragmatically specific</q>. (Section 3.4.1)</td></tr>
 </table>
 </div>
@@ -13300,12 +11681,6 @@
 <div class="cc" id="predicational-(cxn)">
 <h2 class="name"><a href="#predicational-(cxn)">predicational (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#predicational-(inf-cxn)">predicational (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>predicational (<i>cxn</i>)</strong></span><span><a href="#predicational-(inf)">predicational (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">predicational</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#predicate-nominal-construction-(cxn)">predicate nominal construction (<i>cxn</i>)</a></td></tr>
@@ -13324,31 +11699,12 @@
 <span><a href="#predicational-possession-(cxn)">predicational possession (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="predicational-(inf-cxn)">
-<h2 class="name"><a href="#predicational-(inf-cxn)">predicational (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>predicational (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#predicational-(cxn)">predicational (<i>cxn</i>)</a></span><span><a href="#predicational-(inf)">predicational (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">predicational</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the subtype of <a href="#topic-comment-(inf)">topic–comment</a> or <a href="#predication-(inf)">predication information packaging</a> in which membership in an <a href="#object-phrase-(cxn)">object</a> category is what is being predicated; and the <a href="#construction-(def)">construction</a> that expresses that information packaging. <em>Example</em>: in <em>Bill is a teacher</em>, what is being predicated of Bill is that he is a member of the object category of teacher. In other words, <q>predicational</q> is synonymous with <a href="#object-phrase-(cxn)">object</a> <span class="separation"/> <a href="#predication-(inf)">predication</a>. (Section 10.1.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> that expresses a <a href="#predicational-(inf)">predicational</a> information packaging. <em>Example</em>: in <em>Bill is a teacher</em>, what is being predicated of Bill is that he is a member of the object category of teacher. (Section 10.1.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="predicational-(inf)">
 <h2 class="name"><a href="#predicational-(inf)">predicational (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#predicational-(inf-cxn)">predicational (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#predicational-(cxn)">predicational (<i>cxn</i>)</a></span><span><strong>predicational (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">predicational</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -13363,17 +11719,12 @@
 <span><a href="#predicational-location-(inf)">predicational location (<i>inf</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the subtype of <a href="#topic-comment-(inf)">topic–comment</a> or <a href="#predication-(inf)">predication information packaging</a> in which membership in an <a href="#object-phrase-(cxn)">object</a> category is what is being predicated. <em>Example</em>: in <em>Bill is a teacher</em>, what is being predicated of Bill is that he is a member of the object category of teacher. In other words, <q>predicational</q> is synonymous with <a href="#object-phrase-(cxn)">object</a> <span class="separation"/> <a href="#predication-(inf)">predication</a>. (Section 10.1.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="predicational-location-(cxn)">
 <h2 class="name"><a href="#predicational-location-(cxn)">predicational location (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#predicational-location-(inf-cxn)">predicational location (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>predicational location (<i>cxn</i>)</strong></span><span><a href="#predicational-location-(inf)">predicational location (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">predicational location</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -13386,31 +11737,12 @@
 <strong>predicational location (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="predicational-location-(inf-cxn)">
-<h2 class="name"><a href="#predicational-location-(inf-cxn)">predicational location (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>predicational location (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#predicational-location-(cxn)">predicational location (<i>cxn</i>)</a></span><span><a href="#predicational-location-(inf)">predicational location (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">predicational location | predicational locative | locative predication</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a spatial location situation with a <a href="#predicational-(inf)">predicational</a> (<a href="#topic-comment-(inf)">topic–comment</a>) <a href="#information-packaging-(def)">information packaging</a>, such that the <a href="#figure-(sem)">figure</a> in the spatial relation is the <a href="#topic-(inf)">topic</a> and its location (including the <a href="#ground-(sem)">ground</a>) is the <a href="#comment-(inf)">comment</a>; and the <a href="#construction-(def)">construction</a> expressing that <a href="#role-(def)">function</a>. <em>Example</em>: <em>The pot is on the table</em> is an instance of the predicational locative construction. (Section 10.4.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> expressing a <a href="#predicational-location-(inf)">predicational location</a> <span class="separation"/> <a href="#role-(def)">function</a>. <em>Example</em>: <em>The pot is on the table</em> is an instance of the predicational locative construction. (Section 10.4.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="predicational-location-(inf)">
 <h2 class="name"><a href="#predicational-location-(inf)">predicational location (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#predicational-location-(inf-cxn)">predicational location (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#predicational-location-(cxn)">predicational location (<i>cxn</i>)</a></span><span><strong>predicational location (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">predicational location</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -13422,6 +11754,7 @@
 <strong>predicational location (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a spatial location situation with a <a href="#predicational-(inf)">predicational</a> (<a href="#topic-comment-(inf)">topic–comment</a>) <a href="#information-packaging-(def)">information packaging</a>, such that the <a href="#figure-(sem)">figure</a> in the spatial relation is the <a href="#topic-(inf)">topic</a> and its location (including the <a href="#ground-(sem)">ground</a>) is the <a href="#comment-(inf)">comment</a>. <em>Example</em>: <em>The pot is on the table</em> is an instance of the predicational locative construction. (Section 10.4.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="predicational-locative-strategy-(str)">
@@ -13475,7 +11808,7 @@
 <strong>predicational strategy (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-event-(sem)-verb-(cxn)">manner</a> or other <a href="#stative-(sem)">stative component</a> is <a href="#information-packaging-(def)">packaged</a> as the sole <a href="#predication-(inf)">predication</a>, and the <a href="#event-(sem)">event</a> is packaged as the <a href="#subject-argument-(inf)">subject argument</a> of the manner predication. <em>Example</em>: in Mokilese <em>ah kijou dahr</em> <q>He runs fast</q> [lit. <q>his running is fast</q>], the speed is predicated of the event. (Section 14.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> used in the <a href="#stative-complex-predicate-(cxn)">stative complex predicate construction</a> in which the <a href="#manner-complex-predicate-(cxn)">manner</a> or other <a href="#stative-(sem)">stative component</a> is <a href="#information-packaging-(def)">packaged</a> as the sole <a href="#predication-(inf)">predication</a>, and the <a href="#event-(sem)">event</a> is packaged as the <a href="#subject-argument-(inf)">subject argument</a> of the manner predication. <em>Example</em>: in Mokilese <em>ah kijou dahr</em> <q>He runs fast</q> [lit. <q>his running is fast</q>], the speed is predicated of the event. (Section 14.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="predicativization-possessive-strategy-(str)">
@@ -13550,12 +11883,6 @@
 <div class="cc" id="presentational-(cxn)">
 <h2 class="name"><a href="#presentational-(cxn)">presentational (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#presentational-(inf-cxn)">presentational (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>presentational (<i>cxn</i>)</strong></span><span><a href="#presentational-(inf)">presentational (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">presentational</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#predicate-nominal-construction-(cxn)">predicate nominal construction (<i>cxn</i>)</a></td></tr>
@@ -13573,31 +11900,12 @@
 <span><a href="#presentational-possession-(cxn)">presentational possession (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="presentational-(inf-cxn)">
-<h2 class="name"><a href="#presentational-(inf-cxn)">presentational (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>presentational (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#presentational-(cxn)">presentational (<i>cxn</i>)</a></span><span><a href="#presentational-(inf)">presentational (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">presentational</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a type of <a href="#entity-central-(inf)">entity-central</a> <span class="separation"/> <a href="#thetic-(inf)">thetic information packaging</a> that introduces a <a href="#reference,-referent-(inf)">referent</a> into the discourse, in order to make the identity of the referent known to the hearer; and the <a href="#construction-(def)">construction</a> that expresses that information packaging. <em>Example</em>: <em>There's my bicycle</em> and <em>In the corner sat a mouse</em> are sentences that express the presentational information packaging function. Subtypes of the presentational construction are the <a href="#presentational-location-(inf)">presentational location</a> and the <a href="#presentational-possession-(cxn)">presentational possession constructions</a>. (Sections 10.1.2, 10.4)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> that expresses a <a href="#presentational-(inf)">presentational</a> information packaging. <em>Example</em>: <em>There's my bicycle</em> and <em>In the corner sat a mouse</em> are sentences that express the presentational information packaging function. Subtypes of the presentational construction are the <a href="#presentational-location-(inf)">presentational location</a> and the <a href="#presentational-possession-(cxn)">presentational possession constructions</a>. (Sections 10.1.2, 10.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="presentational-(inf)">
 <h2 class="name"><a href="#presentational-(inf)">presentational (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#presentational-(inf-cxn)">presentational (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#presentational-(cxn)">presentational (<i>cxn</i>)</a></span><span><strong>presentational (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">presentational</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -13612,17 +11920,12 @@
 <span><a href="#presentational-location-(inf)">presentational location (<i>inf</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a type of <a href="#entity-central-(inf)">entity-central</a> <span class="separation"/> <a href="#thetic-(inf)">thetic information packaging</a> that introduces a <a href="#reference,-referent-(inf)">referent</a> into the discourse, in order to make the identity of the referent known to the hearer. <em>Example</em>: <em>There's my bicycle</em> and <em>In the corner sat a mouse</em> are sentences that express the presentational information packaging function. (Sections 10.1.2, 10.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="presentational-location-(cxn)">
 <h2 class="name"><a href="#presentational-location-(cxn)">presentational location (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#presentational-location-(inf-cxn)">presentational location (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>presentational location (<i>cxn</i>)</strong></span><span><a href="#presentational-location-(inf)">presentational location (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">presentational location | presentational locative</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -13635,31 +11938,12 @@
 <strong>presentational location (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="presentational-location-(inf-cxn)">
-<h2 class="name"><a href="#presentational-location-(inf-cxn)">presentational location (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>presentational location (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#presentational-location-(cxn)">presentational location (<i>cxn</i>)</a></span><span><a href="#presentational-location-(inf)">presentational location (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">presentational location</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#presentational-(inf)">presentational information packaging</a> of the spatial location relation in which the <a href="#figure-(sem)">figure</a> in the locative relation is introduced in the discourse, <a href="#anchor-(inf)">anchored</a> by the <a href="#ground-(sem)">ground</a> <span class="separation"/> <a href="#object-phrase-(cxn)">object</a>; and the <a href="#construction-(def)">construction</a> expressing this <a href="#role-(def)">function</a>. <em>Example</em>: in <em>In the room was a request for breakfast</em>, the request for breakfast is being introduced into the discourse, anchored by its spatial relation to the room. (Sections 10.4.1, 10.4.3)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> expressing the <a href="#presentational-location-(inf)">presentational location</a> <span class="separation"/> <a href="#role-(def)">function</a>. <em>Example</em>: in <em>In the room was a request for breakfast</em>, the request for breakfast is being introduced into the discourse, anchored by its spatial relation to the room. (Sections 10.4.1, 10.4.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="presentational-location-(inf)">
 <h2 class="name"><a href="#presentational-location-(inf)">presentational location (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#presentational-location-(inf-cxn)">presentational location (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#presentational-location-(cxn)">presentational location (<i>cxn</i>)</a></span><span><strong>presentational location (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">presentational location</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -13671,6 +11955,7 @@
 <strong>presentational location (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#presentational-(inf)">presentational information packaging</a> of the spatial location relation in which the <a href="#figure-(sem)">figure</a> in the locative relation is introduced in the discourse, <a href="#anchor-(inf)">anchored</a> by the <a href="#ground-(sem)">ground</a> <span class="separation"/> <a href="#object-phrase-(cxn)">object</a>. <em>Example</em>: in <em>In the room was a request for breakfast</em>, the request for breakfast is being introduced into the discourse, anchored by its spatial relation to the room. (Sections 10.4.1, 10.4.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="presentational-possession-(cxn)">
@@ -13712,12 +11997,6 @@
 <div class="cc" id="pretense-event-(sem)">
 <h2 class="name"><a href="#pretense-event-(sem)">pretense event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#pretense-event-(sem)-predicate-(cxn)">pretense event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>pretense event (<i>sem</i>)</strong></span><span><a href="#pretense-predicate-(cxn)">pretense predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">pretence event | pretense event</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -13729,31 +12008,12 @@
 <strong>pretense event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="pretense-event-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#pretense-event-(sem)-predicate-(cxn)">pretense event (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>pretense event (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#pretense-event-(sem)">pretense event (<i>sem</i>)</a></span><span><a href="#pretense-predicate-(cxn)">pretense predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">pretense event/predicate | pretense | pretence event/predicate | pretence</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#propositional-attitude-event-(sem)">propositional attitude event</a> in which the speaker, or the <a href="#experiencer-(sem)">experiencer</a> of the pretense event, presents the <a href="#proposition-(sem)">proposition</a> expressed by the <a href="#complement-dependent-clause-(cxn)">complement</a> as true in an alternative reality or <a href="#mental-space-(sem)">mental space</a>; and a <a href="#predicate-(cxn)">predicate</a> expressing such an event. <em>Example</em>: in <em>Ira pretended that the guests had already left</em>, the proposition that the guests had already left is presented as true in an alternative reality from the shared beliefs of the interlocutors (or, for that matter, Ira). There is a strong implicature that the proposition does not hold in reality (that is, the shared beliefs of the interlocutors). (Section 18.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#propositional-attitude-event-(sem)">propositional attitude event</a> in which the speaker, or the <a href="#experiencer-(sem)">experiencer</a> of the pretense event, presents the <a href="#proposition-(sem)">proposition</a> expressed by the <a href="#complement-dependent-clause-(cxn)">complement</a> as true in an alternative reality or <a href="#mental-space-(sem)">mental space</a>. <em>Example</em>: in <em>Ira pretended that the guests had already left</em>, the proposition that the guests had already left is presented as true in an alternative reality from the shared beliefs of the interlocutors (or, for that matter, Ira). There is a strong implicature that the proposition does not hold in reality (that is, the shared beliefs of the interlocutors). (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="pretense-predicate-(cxn)">
 <h2 class="name"><a href="#pretense-predicate-(cxn)">pretense predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#pretense-event-(sem)-predicate-(cxn)">pretense event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#pretense-event-(sem)">pretense event (<i>sem</i>)</a></span><span><strong>pretense predicate (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">pretense predicate | pretence predicate</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -13765,6 +12025,7 @@
 <strong>pretense predicate (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#predicate-(cxn)">predicate</a> expressing a <a href="#pretense-event-(sem)">pretense event</a>. <em>Example</em>: in <em>Ira pretended that the guests had already left</em>, the proposition that the guests had already left is presented as true in an alternative reality from the shared beliefs of the interlocutors (or, for that matter, Ira). There is a strong implicature that the proposition does not hold in reality (that is, the shared beliefs of the interlocutors). (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="primary-object-category-(str)">
@@ -13788,12 +12049,6 @@
 <div class="cc" id="prohibitive-(cxn)">
 <h2 class="name"><a href="#prohibitive-(cxn)">prohibitive (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#prohibitive-(inf-cxn)">prohibitive (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>prohibitive (<i>cxn</i>)</strong></span><span><a href="#prohibitive-(inf)">prohibitive (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">prohibitive</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -13806,31 +12061,12 @@
 <strong>prohibitive (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="prohibitive-(inf-cxn)">
-<h2 class="name"><a href="#prohibitive-(inf-cxn)">prohibitive (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>prohibitive (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#prohibitive-(cxn)">prohibitive (<i>cxn</i>)</a></span><span><a href="#prohibitive-(inf)">prohibitive (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">prohibitive</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#negative-polarity-(sem)">negative</a> <span class="separation"/> <a href="#imperative-hortative-(inf)">imperative–hortative</a> <span class="separation"/> <a href="#speech-acts-(inf)">speech act</a>, and the <a href="#construction-(def)">construction</a> that expresses that speech act. <em>Example</em>: English <em>Don't be a fool!</em> is an instance of a prohibitive; the construction uses a special prohibitive morpheme <em>Don't</em> to express prohibitive function. (Section 12.4.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> that expresses a <a href="#prohibitive-(inf)">prohibitive</a> speech act. <em>Example</em>: English <em>Don't be a fool!</em> is an instance of a prohibitive; the construction uses a special prohibitive morpheme <em>Don't</em> to express prohibitive function. (Section 12.4.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="prohibitive-(inf)">
 <h2 class="name"><a href="#prohibitive-(inf)">prohibitive (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#prohibitive-(inf-cxn)">prohibitive (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#prohibitive-(cxn)">prohibitive (<i>cxn</i>)</a></span><span><strong>prohibitive (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">prohibitive</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -13842,6 +12078,7 @@
 <strong>prohibitive (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#negative-polarity-(sem)">negative</a> <span class="separation"/> <a href="#imperative-hortative-(inf)">imperative–hortative</a> <span class="separation"/> <a href="#speech-acts-(inf)">speech act</a>. <em>Example</em>: English <em>Don't be a fool!</em> is an instance of a prohibitive. (Section 12.4.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="pronominal-argument-complex-predicate-(cxn)">
@@ -14036,14 +12273,8 @@
 <div class="cc" id="propositional-attitude-event-(sem)">
 <h2 class="name"><a href="#propositional-attitude-event-(sem)">propositional attitude event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#propositional-attitude-event-(sem)-predicate-(cxn)">propositional attitude event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>propositional attitude event (<i>sem</i>)</strong></span><span><a href="#propositional-attitude-predicate-(cxn)">propositional attitude predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">propositional attitude event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">propositional attitude event | propositional attitude</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#independent-time-reference-(sem)">independent time reference (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -14058,31 +12289,12 @@
 <span><a href="#pretense-event-(sem)">pretense event (<i>sem</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="propositional-attitude-event-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#propositional-attitude-event-(sem)-predicate-(cxn)">propositional attitude event (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>propositional attitude event (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#propositional-attitude-event-(sem)">propositional attitude event (<i>sem</i>)</a></span><span><a href="#propositional-attitude-predicate-(cxn)">propositional attitude predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">propositional attitude event/predicate | propositional attitude</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> of thinking, believing, and so on that expresses an attitude of the <a href="#experiencer-(sem)">experiencer</a> toward the truth of the <a href="#proposition-(sem)">proposition</a> expressed by the <a href="#complement-dependent-clause-(cxn)">complement</a>; and the <a href="#predicate-(cxn)">predicate</a> expressing such an event. <em>Example</em>: in <em>Aram thought that the pianist was very good</em>, the <a href="#complement-taking-predicate-(cxn)">complement-taking predicate</a> <em>thought</em> denotes a propositional attitude event. Special cases of propositional attitude events are <a href="#knowledge-event-(sem)">knowledge events</a> and <a href="#pretense-event-(sem)">pretense events</a>. (Section 18.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> of thinking, believing, and so on that expresses an attitude of the <a href="#experiencer-(sem)">experiencer</a> toward the truth of the <a href="#proposition-(sem)">proposition</a> expressed by the <a href="#complement-dependent-clause-(cxn)">complement</a>. <em>Example</em>: in <em>Aram thought that the pianist was very good</em>, the <a href="#complement-taking-predicate-(cxn)">complement-taking predicate</a> <em>thought</em> denotes a propositional attitude event. Special cases of propositional attitude events are <a href="#knowledge-event-(sem)">knowledge events</a> and <a href="#pretense-event-(sem)">pretense events</a>. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="propositional-attitude-predicate-(cxn)">
 <h2 class="name"><a href="#propositional-attitude-predicate-(cxn)">propositional attitude predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#propositional-attitude-event-(sem)-predicate-(cxn)">propositional attitude event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#propositional-attitude-event-(sem)">propositional attitude event (<i>sem</i>)</a></span><span><strong>propositional attitude predicate (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">propositional attitude predicate</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -14098,6 +12310,7 @@
 <span><a href="#pretense-predicate-(cxn)">pretense predicate (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#predicate-(cxn)">predicate</a> expressing such a <a href="#propositional-attitude-event-(sem)">propositional attitude event</a>. <em>Example</em>: in <em>Aram thought that the pianist was very good</em>, the <a href="#complement-taking-predicate-(cxn)">complement-taking predicate</a> <em>thought</em> denotes a propositional attitude event. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="propositional-content-(sem)">
@@ -14139,14 +12352,8 @@
 <div class="cc" id="protasis-(cxn)">
 <h2 class="name"><a href="#protasis-(cxn)">protasis (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#protasis-(sem-cxn)">protasis (<i>sem/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>protasis (<i>cxn</i>)</strong></span><span><a href="#protasis-(sem)">protasis (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">protasis</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">protasis | antecedent</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -14156,31 +12363,12 @@
 <strong>protasis (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="protasis-(sem-cxn)">
-<h2 class="name"><a href="#protasis-(sem-cxn)">protasis (<i>sem/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>protasis (<i>sem/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#protasis-(cxn)">protasis (<i>cxn</i>)</a></span><span><a href="#protasis-(sem)">protasis (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">protasis | antecedent</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#clause-(cxn)">clause</a> expressing the causally antecedent <a href="#proposition-(sem)">proposition</a> in a <a href="#causal-(sem)">causal</a>, <a href="#conditional-relation-(sem)-construction-(cxn)">conditional</a>, <a href="#concessive-relation-(sem)-construction-(cxn)">concessive</a>, <a href="#concessive-conditional-relation-(sem)-construction-(cxn)">concessive conditional</a>, or <a href="#comparative-conditional-construction-(cxn)">comparative conditional construction</a>; or the proposition or <a href="#event-(sem)">event</a> denoted by the clause. <em>Example</em>: in <em>If you press this button, the door will open</em>, <em>If you press this button</em> is the protasis; <em>the door will open</em> is the <a href="#apodosis-(sem)">apodosis</a>. Since the conditional relations are defined in terms of both logical implication and causal relation, the semantic use of <q>protasis</q> can be distinguished as <q>protasis proposition</q> or <q>protasis event</q>. (Section 17.3.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#clause-(cxn)">clause</a> expressing the causally antecedent <a href="#proposition-(sem)">proposition</a> in a <a href="#causal-(sem)">causal</a>, <a href="#conditional-relation-(sem)">conditional</a>, <a href="#concessive-relation-(sem)">concessive</a>, <a href="#concessive-conditional-relation-(sem)">concessive conditional</a>, or <a href="#comparative-conditional-construction-(cxn)">comparative conditional construction</a>. <em>Example</em>: in <em>If you press this button, the door will open</em>, <em>If you press this button</em> is the protasis; <em>the door will open</em> is the <a href="#apodosis-(sem)">apodosis</a>. (Section 17.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="protasis-(sem)">
 <h2 class="name"><a href="#protasis-(sem)">protasis (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#protasis-(sem-cxn)">protasis (<i>sem/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#protasis-(cxn)">protasis (<i>cxn</i>)</a></span><span><strong>protasis (<i>sem</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">protasis</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#epistemic-stance-(sem)">epistemic stance (<i>sem</i>)</a> | <a href="#conditional-relation-(sem)">conditional relation (<i>sem</i>)</a></td></tr>
@@ -14188,11 +12376,13 @@
 <table>
 <tr><td class="flex">
 <span><a href="#proposition-(sem)">proposition (<i>sem</i>)</a></span>
+<span><a href="#event-(sem)">event (<i>sem</i>)</a></span>
 </td></tr>
 <tr><td>
 <strong>protasis (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the proposition or <a href="#event-(sem)">event</a> denoted by a <a href="#protasis-(sem)">protasis</a> clause. <em>Example</em>: in <em>If you press this button, the door will open</em>, <em>If you press this button</em> is the protasis; <em>the door will open</em> is the <a href="#apodosis-(sem)">apodosis</a>. Since the conditional relations are defined in terms of both logical implication and causal relation, the semantic use of <q>protasis</q> can be distinguished as <q>protasis proposition</q> or <q>protasis event</q>. (Section 17.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="prototypical-construction-(cxn)">
@@ -14311,12 +12501,6 @@
 <div class="cc" id="pursuit-event-(sem)">
 <h2 class="name"><a href="#pursuit-event-(sem)">pursuit event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#pursuit-event-(sem)-verb-(cxn)">pursuit event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>pursuit event (<i>sem</i>)</strong></span><span><a href="#pursuit-verb-(cxn)">pursuit verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">pursuit event</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -14328,31 +12512,12 @@
 <strong>pursuit event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="pursuit-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#pursuit-event-(sem)-verb-(cxn)">pursuit event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>pursuit event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#pursuit-event-(sem)">pursuit event (<i>sem</i>)</a></span><span><a href="#pursuit-verb-(cxn)">pursuit verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">pursuit event/verb | pursuit</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition"><a href="#event-(sem)">events</a> in which one <a href="#participant-(sem)">participant's</a> motion or location is directed toward another participant; and the <a href="#verb-(cxn)">verb</a> expressing such an event. <em>Examples</em>: pursuit events include following, chasing, searching for something, and waiting for someone/something; and <em>follow</em>, <em>chase</em>, <em>search (for)</em>, and <em>wait (for)</em> are pursuit verbs. (Section 7.3.3)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition"><a href="#event-(sem)">events</a> in which one <a href="#participant-(sem)">participant's</a> motion or location is directed toward another participant. <em>Examples</em>: pursuit events include following, chasing, searching for something, and waiting for someone/something; and <em>follow</em>, <em>chase</em>, <em>search (for)</em>, and <em>wait (for)</em> are pursuit verbs. (Section 7.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="pursuit-verb-(cxn)">
 <h2 class="name"><a href="#pursuit-verb-(cxn)">pursuit verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#pursuit-event-(sem)-verb-(cxn)">pursuit event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#pursuit-event-(sem)">pursuit event (<i>sem</i>)</a></span><span><strong>pursuit verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">pursuit verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -14364,6 +12529,7 @@
 <strong>pursuit verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing a <a href="#pursuit-event-(sem)">pursuit event</a>. <em>Examples</em>: pursuit events include following, chasing, searching for something, and waiting for someone/something; and <em>follow</em>, <em>chase</em>, <em>search (for)</em>, and <em>wait (for)</em> are pursuit verbs. (Section 7.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="quantifier-(cxn)">
@@ -14393,12 +12559,6 @@
 <div class="cc" id="question-pronoun-(cxn)">
 <h2 class="name"><a href="#question-pronoun-(cxn)">question pronoun (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#question-referent-(inf)-pronoun-(cxn)">question referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>question pronoun (<i>cxn</i>)</strong></span><span><a href="#question-referent-(inf)">question referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">question pronoun</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#information-question-(cxn)">information question (<i>cxn</i>)</a></td></tr>
@@ -14411,17 +12571,12 @@
 <strong>question pronoun (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#pronoun-(cxn)">pronoun</a> that expresses a <a href="#question-referent-(inf)">question referent</a>. (Section 3.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="question-referent-(inf)">
 <h2 class="name"><a href="#question-referent-(inf)">question referent (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#question-referent-(inf)-pronoun-(cxn)">question referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#question-pronoun-(cxn)">question pronoun (<i>cxn</i>)</a></span><span><strong>question referent (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">question referent</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -14433,19 +12588,6 @@
 <strong>question referent (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="question-referent-(inf)-pronoun-(cxn)">
-<h2 class="name"><a href="#question-referent-(inf)-pronoun-(cxn)">question referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>question referent (<i>inf</i>) / pronoun (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#question-pronoun-(cxn)">question pronoun (<i>cxn</i>)</a></span><span><a href="#question-referent-(inf)">question referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">question referent/pronoun | question</td></tr>
 <tr><th>Definition</th> <td class="ccinfo definition">an unspecified <a href="#reference,-referent-(inf)">referent</a> in the scope of <a href="#interrogative-(inf)">interrogation</a>, especially <a href="#polarity-(sem)">polar</a> <span class="separation"/> <a href="#interrogative-(inf)">interrogatives</a>. <em>Example</em>: in <em>Can you hear <strong>anything</strong>?</em>, <em>anything</em> is a question pronoun expressing a referent that only <q class="dq">exists</q> in a hypothetical world, the possibility of whose existence is being entertained by the questioner. (Section 3.5)</td></tr>
 </table>
 </div>
@@ -14464,7 +12606,7 @@
 <strong>quotative marker (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#complementizer-(str)">complementizer</a> used with <a href="#direct-report-(str)">direct reports</a>. <em>Example</em>: in Kobon <em>ban nöp hagöp</em> [<em>yad ram arabin</em>] <em>a göp</em> <q>Who said to you, <q class="dq">I am going home</q>?</q>, <em>a</em> is a quotative marker used with the direct report <a href="#utterance-event-(sem)-predicate-(cxn)">utterance</a> <span class="separation"/> <a href="#complement-dependent-clause-(cxn)">complement</a> <em>yad ram arabin</em> <q>I am going home</q>. Like the direct report <a href="#strategy-(def)">strategy</a> it accompanies, a quotative marker originates with utterance <a href="#complement-clause-construction-(cxn)">complement clause constructions</a> but is extended to other complement clause constructions lower in the <a href="#Binding-Hierarchy-(def)">Binding Hierarchy</a>. (Section 18.3.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#complementizer-(str)">complementizer</a> used with <a href="#direct-report-(str)">direct reports</a>. <em>Example</em>: in Kobon <em>ban nöp hagöp</em> [<em>yad ram arabin</em>] <em>a göp</em> <q>Who said to you, <q class="dq">I am going home</q>?</q>, <em>a</em> is a quotative marker used with the direct report <a href="#utterance-event-(sem)">utterance</a> <span class="separation"/> <a href="#complement-dependent-clause-(cxn)">complement</a> <em>yad ram arabin</em> <q>I am going home</q>. Like the direct report <a href="#strategy-(def)">strategy</a> it accompanies, a quotative marker originates with utterance <a href="#complement-clause-construction-(cxn)">complement clause constructions</a> but is extended to other complement clause constructions lower in the <a href="#Binding-Hierarchy-(def)">Binding Hierarchy</a>. (Section 18.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="R-role-(sem)">
@@ -14508,12 +12650,6 @@
 <div class="cc" id="reciprocal-construction-(cxn)">
 <h2 class="name"><a href="#reciprocal-construction-(cxn)">reciprocal construction (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#reciprocal-event-(sem)-construction-(cxn)">reciprocal event (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>reciprocal construction (<i>cxn</i>)</strong></span><span><a href="#reciprocal-event-(sem)">reciprocal event (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">reciprocal construction</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -14525,17 +12661,12 @@
 <strong>reciprocal construction (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> expressing such a <a href="#reciprocal-event-(sem)">reciprocal event</a>. <em>Example</em>: in <em>Mary and Sue praised each other</em>, Mary praises Sue and Sue praises Mary. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="reciprocal-event-(sem)">
 <h2 class="name"><a href="#reciprocal-event-(sem)">reciprocal event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#reciprocal-event-(sem)-construction-(cxn)">reciprocal event (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#reciprocal-construction-(cxn)">reciprocal construction (<i>cxn</i>)</a></span><span><strong>reciprocal event (<i>sem</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">reciprocal event</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#monoclausal-transitive-reciprocal-strategy-(str)">monoclausal transitive reciprocal strategy (<i>str</i>)</a></td></tr>
@@ -14548,20 +12679,7 @@
 <strong>reciprocal event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="reciprocal-event-(sem)-construction-(cxn)">
-<h2 class="name"><a href="#reciprocal-event-(sem)-construction-(cxn)">reciprocal event (<i>sem</i>) / construction (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>reciprocal event (<i>sem</i>) / construction (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#reciprocal-construction-(cxn)">reciprocal construction (<i>cxn</i>)</a></span><span><a href="#reciprocal-event-(sem)">reciprocal event (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">reciprocal event/construction | reciprocal</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> type in which one <a href="#participant-(sem)">participant</a> acts upon another participant, and the second participant acts on the first in the same way; and the <a href="#construction-(def)">construction</a> expressing such an event. That is, each participant is both the <a href="#initiator-(sem)">initiator</a> and <a href="#endpoint-(sem)">endpoint</a> of <a href="#causal-structure-(sem)">transmission of force</a> for the same type of action. <em>Example</em>: in <em>Mary and Sue praised each other</em>, Mary praises Sue and Sue praises Mary. (Section 7.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> type in which one <a href="#participant-(sem)">participant</a> acts upon another participant, and the second participant acts on the first in the same way. That is, each participant is both the <a href="#initiator-(sem)">initiator</a> and <a href="#endpoint-(sem)">endpoint</a> of <a href="#causal-structure-(sem)">transmission of force</a> for the same type of action. <em>Example</em>: in <em>Mary and Sue praised each other</em>, Mary praises Sue and Sue praises Mary. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="recruitment-strategy-(str)">
@@ -14704,12 +12822,6 @@
 <div class="cc" id="reflexive-construction-(cxn)">
 <h2 class="name"><a href="#reflexive-construction-(cxn)">reflexive construction (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#reflexive-event-(sem)-construction-(cxn)">reflexive event (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>reflexive construction (<i>cxn</i>)</strong></span><span><a href="#reflexive-event-(sem)">reflexive event (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">reflexive construction</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -14721,19 +12833,14 @@
 <strong>reflexive construction (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> expressing a <a href="#reflexive-event-(sem)">reflexive event</a>. <em>Examples</em>: reflexive events may be direct, when there is no other participant, as in <em>I saw myself</em>; or indirect, when there is another participant in an intermediate position in the <a href="#causal-chain-(sem)">causal chain</a>, as in <em>Sally baked a cake for herself</em>, whose causal structure is Sally &rarr; cake &rarr; Sally. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="reflexive-event-(sem)">
 <h2 class="name"><a href="#reflexive-event-(sem)">reflexive event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#reflexive-event-(sem)-construction-(cxn)">reflexive event (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#reflexive-construction-(cxn)">reflexive construction (<i>cxn</i>)</a></span><span><strong>reflexive event (<i>sem</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">reflexive event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">reflexive event | reflexive</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -14743,20 +12850,7 @@
 <strong>reflexive event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="reflexive-event-(sem)-construction-(cxn)">
-<h2 class="name"><a href="#reflexive-event-(sem)-construction-(cxn)">reflexive event (<i>sem</i>) / construction (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>reflexive event (<i>sem</i>) / construction (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#reflexive-construction-(cxn)">reflexive construction (<i>cxn</i>)</a></span><span><a href="#reflexive-event-(sem)">reflexive event (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">reflexive event/construction | reflexive</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> type in which a <a href="#participant-(sem)">participant</a> acts upon themself – that is, the participant is both the <a href="#initiator-(sem)">initiator</a> and <a href="#endpoint-(sem)">endpoint</a> of <a href="#causal-structure-(sem)">transmission of force</a>; and the <a href="#construction-(def)">construction</a> expressing such an event. <em>Examples</em>: reflexive events may be direct, when there is no other participant, as in <em>I saw myself</em>; or indirect, when there is another participant in an intermediate position in the <a href="#causal-chain-(sem)">causal chain</a>, as in <em>Sally baked a cake for herself</em>, whose causal structure is Sally &rarr; cake &rarr; Sally. (Section 7.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> type in which a <a href="#participant-(sem)">participant</a> acts upon themself – that is, the participant is both the <a href="#initiator-(sem)">initiator</a> and <a href="#endpoint-(sem)">endpoint</a> of <a href="#causal-structure-(sem)">transmission of force</a>. <em>Examples</em>: reflexive events may be direct, when there is no other participant, as in <em>I saw myself</em>; or indirect, when there is another participant in an intermediate position in the <a href="#causal-chain-(sem)">causal chain</a>, as in <em>Sally baked a cake for herself</em>, whose causal structure is Sally &rarr; cake &rarr; Sally. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="rejecting-(inf)">
@@ -14949,7 +13043,7 @@
 <strong>relative strategy (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#strategy-(def)">strategy</a> for <a href="#comparative-referent-(inf)-pronoun-(cxn)">comparative</a> (and possibly <a href="#equative-construction-(cxn)">equative</a>) <a href="#construction-(def)">constructions</a> which directly expresses two of the <a href="#proposition-(sem)">propositions</a> that form the <a href="#meaning-(def)">meaning</a> of the comparative – that the <a href="#gradable-predicative-scale-(sem)">gradable predicative scale</a> applies to the <a href="#comparee-(sem)">comparee</a>, and that the comparee exceeds the <a href="#standard-(sem)">standard</a> on the scale. That is to say, the relative strategy <a href="#recruitment-strategy-(str)">recruits</a> a <a href="#same-subject-(inf)">same-subject</a>, <a href="#conditional-deranking-system-(str)">conditionally deranked</a>, usually <a href="#simultaneous-(sem)">simultaneous</a> <u>temporal</u> <a href="#complex-sentence-(cxn)">complex sentence construction</a> to express comparison. The <a href="#exceed-comparative-(str)">exceed comparative</a> is an example of the relative strategy; the <a href="#conjoined-exceed-comparative-(str)">conjoined exceed strategy</a> appears to be a related type. (Section 17.2.3)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#strategy-(def)">strategy</a> for <a href="#comparative-construction-(cxn)">comparative</a> (and possibly <a href="#equative-construction-(cxn)">equative</a>) <a href="#construction-(def)">constructions</a> which directly expresses two of the <a href="#proposition-(sem)">propositions</a> that form the <a href="#meaning-(def)">meaning</a> of the comparative – that the <a href="#gradable-predicative-scale-(sem)">gradable predicative scale</a> applies to the <a href="#comparee-(sem)">comparee</a>, and that the comparee exceeds the <a href="#standard-(sem)">standard</a> on the scale. That is to say, the relative strategy <a href="#recruitment-strategy-(str)">recruits</a> a <a href="#same-subject-(inf)">same-subject</a>, <a href="#conditional-deranking-system-(str)">conditionally deranked</a>, usually <a href="#simultaneous-(sem)">simultaneous</a> <u>temporal</u> <a href="#complex-sentence-(cxn)">complex sentence construction</a> to express comparison. The <a href="#exceed-comparative-(str)">exceed comparative</a> is an example of the relative strategy; the <a href="#conjoined-exceed-comparative-(str)">conjoined exceed strategy</a> appears to be a related type. (Section 17.2.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="relative-based-equative-(str)">
@@ -14967,7 +13061,7 @@
 <strong>relative-based equative (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#derived-case-(str)">derived-case strategy</a> for <a href="#equative-construction-(cxn)">equative constructions</a> which consists of a <a href="#relative-clause-(cxn)">relative clause</a>-like <a href="#construction-(def)">construction</a> where the <a href="#matrix-clause-(cxn)">matrix clause</a> expresses that the <a href="#gradable-predicative-scale-(sem)">gradable predicative scale</a> applies to the <a href="#comparee-(sem)">comparee</a>, and a relative clause expresses that the same scale applies to the <a href="#standard-(sem)">standard</a>. The relative clause is reduced to a <a href="#relativizer-(str)">relativizer</a> and an <a href="#argument-phrase-(cxn)">argument phrase</a> expressing the standard; the <a href="#zero-strategy-(str)">zero strategy</a> is used for <a href="#predicate-identity-(cxn)">predicate identity</a>. <em>Example</em>: Lithuanian <em>Šiandien taip šalta kaip vakar</em> <q>Today it is as cold as yesterday</q> is an instance of the relative-based equative strategy: <em>Šiandien taip šalta</em> <q>today [is] so cold</q> is the matrix clause, with the degree marker <em>taip</em> <q>so</q>, and <em>kaip vakar</em> <q>how yesterday</q> is the relative-based clause, with the pronoun <em>kaip</em> <q>how</q>, the standard, <q>yesterday</q>, and a zero predicate. Typically the relative-based equative recruits a correlative relative clause, with a <a href="#free-relative-clause-(cxn)">free</a> (<a href="#indefinite-pronoun-article-(cxn)">indefinite head</a>) <a href="#relative-clause-(cxn)">relative</a> or interrogative-based <a href="#relative-pronoun-(cxn)">relative pronoun</a>. (Section 17.2.4)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#derived-case-(str)">derived-case strategy</a> for <a href="#equative-construction-(cxn)">equative constructions</a> which consists of a <a href="#relative-clause-(cxn)">relative clause</a>-like <a href="#construction-(def)">construction</a> where the <a href="#matrix-clause-(cxn)">matrix clause</a> expresses that the <a href="#gradable-predicative-scale-(sem)">gradable predicative scale</a> applies to the <a href="#comparee-(sem)">comparee</a>, and a relative clause expresses that the same scale applies to the <a href="#standard-(sem)">standard</a>. The relative clause is reduced to a <a href="#relativizer-(str)">relativizer</a> and an <a href="#argument-phrase-(cxn)">argument phrase</a> expressing the standard; the <a href="#zero-strategy-(str)">zero strategy</a> is used for <a href="#predicate-identity-(cxn)">predicate identity</a>. <em>Example</em>: Lithuanian <em>Šiandien taip šalta kaip vakar</em> <q>Today it is as cold as yesterday</q> is an instance of the relative-based equative strategy: <em>Šiandien taip šalta</em> <q>today [is] so cold</q> is the matrix clause, with the degree marker <em>taip</em> <q>so</q>, and <em>kaip vakar</em> <q>how yesterday</q> is the relative-based clause, with the pronoun <em>kaip</em> <q>how</q>, the standard, <q>yesterday</q>, and a zero predicate. Typically the relative-based equative recruits a correlative relative clause, with a <a href="#free-relative-clause-(cxn)">free</a> (<a href="#indefinite-pronoun-(cxn)">indefinite head</a>) <a href="#relative-clause-(cxn)">relative</a> or interrogative-based <a href="#relative-pronoun-(cxn)">relative pronoun</a>. (Section 17.2.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="relativizer-(str)">
@@ -14991,14 +13085,8 @@
 <div class="cc" id="removal-event-(sem)">
 <h2 class="name"><a href="#removal-event-(sem)">removal event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#removal-event-(sem)-verb-(cxn)">removal event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>removal event (<i>sem</i>)</strong></span><span><a href="#removal-verb-(cxn)">removal verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">removal event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">removal event | removal</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -15008,31 +13096,12 @@
 <strong>removal event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="removal-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#removal-event-(sem)-verb-(cxn)">removal event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>removal event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#removal-event-(sem)">removal event (<i>sem</i>)</a></span><span><a href="#removal-verb-(cxn)">removal verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">removal event/verb | removal</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> describing removal of an <a href="#object-phrase-(cxn)">object</a> from another object; and the <a href="#verb-(cxn)">verb</a> expressing such an event. <em>Example</em>: scrubbing is a removal event, and <em>scrub</em> is a removal verb. (Section 7.3.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> describing removal of an <a href="#object-phrase-(cxn)">object</a> from another object. <em>Example</em>: scrubbing is a removal event. (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="removal-verb-(cxn)">
 <h2 class="name"><a href="#removal-verb-(cxn)">removal verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#removal-event-(sem)-verb-(cxn)">removal event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#removal-event-(sem)">removal event (<i>sem</i>)</a></span><span><strong>removal verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">removal verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -15045,6 +13114,7 @@
 <strong>removal verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing a <a href="#removal-event-(sem)">removal event</a>. <em>Example</em>: scrubbing is a removal event, and <em>scrub</em> is a removal verb. (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="repeater-(str)">
@@ -15084,12 +13154,6 @@
 <div class="cc" id="response-(cxn)">
 <h2 class="name"><a href="#response-(cxn)">response (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#response-(inf-cxn)">response (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>response (<i>cxn</i>)</strong></span><span><a href="#response-(inf)">response (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">response</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#interrogative-(cxn)">interrogative (<i>cxn</i>)</a></td></tr>
@@ -15106,33 +13170,14 @@
 <span><a href="#polarity-response-(cxn)">polarity response (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="response-(inf-cxn)">
-<h2 class="name"><a href="#response-(inf-cxn)">response (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>response (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#response-(cxn)">response (<i>cxn</i>)</a></span><span><a href="#response-(inf)">response (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">response</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the answer to an <a href="#interrogative-(inf)">interrogative</a> (question) <a href="#speech-acts-(inf)">speech act</a>; and the <a href="#construction-(def)">construction</a> expressing the answer. Like interrogatives, responses are divided into <a href="#polarity-response-(inf)">polarity responses</a> and <a href="#information-question-response-(inf)">information (question) responses</a>.</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> expressing a <a href="#response-(inf)">answer</a> <span class="separation"/> <a href="#role-(def)">function</a>. Like interrogatives, responses are divided into <a href="#polarity-response-(inf)">polarity responses</a> and <a href="#information-question-response-(inf)">information (question) responses</a>.</td></tr>
 </table>
 </div>
 <div class="cc" id="response-(inf)">
 <h2 class="name"><a href="#response-(inf)">response (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#response-(inf-cxn)">response (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#response-(cxn)">response (<i>cxn</i>)</a></span><span><strong>response (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">response</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">response | answer</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#interrogative-(inf)">interrogative (<i>inf</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -15147,6 +13192,7 @@
 <span><a href="#polarity-response-(inf)">polarity response (<i>inf</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the answer to an <a href="#interrogative-(inf)">interrogative</a> (question) <a href="#speech-acts-(inf)">speech act</a>. Like interrogatives, responses are divided into <a href="#polarity-response-(inf)">polarity responses</a> and <a href="#information-question-response-(inf)">information (question) responses</a>.</td></tr>
 </table>
 </div>
 <div class="cc" id="restricting-(inf)">
@@ -15204,14 +13250,8 @@
 <div class="cc" id="result-event-(sem)">
 <h2 class="name"><a href="#result-event-(sem)">result event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#result-event-(sem)-verb-(cxn)">result event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>result event (<i>sem</i>)</strong></span><span><a href="#result-verb-(cxn)">result verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">result event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">result event | result</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -15221,31 +13261,12 @@
 <strong>result event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="result-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#result-event-(sem)-verb-(cxn)">result event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>result event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#result-event-(sem)">result event (<i>sem</i>)</a></span><span><a href="#result-verb-(cxn)">result verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">result event/verb | result</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> that is described in terms of reaching a result state, often by means of a scalar change (<a href="#directed-change-(sem)">directed change</a>), and the <a href="#verb-(cxn)">verb</a> expressing such an event. <em>Example</em>: in <em>Peter broke the window</em>, the event is described in terms of the result state that is reached (a broken window). (Section 7.3.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> that is described in terms of reaching a result state, often by means of a scalar change (<a href="#directed-change-(sem)">directed change</a>). <em>Example</em>: in <em>Peter broke the window</em>, the event is described in terms of the result state that is reached (a broken window). (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="result-verb-(cxn)">
 <h2 class="name"><a href="#result-verb-(cxn)">result verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#result-event-(sem)-verb-(cxn)">result event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#result-event-(sem)">result event (<i>sem</i>)</a></span><span><strong>result verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">result verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -15264,6 +13285,7 @@
 <span><a href="#removal-verb-(cxn)">removal verb (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing a <a href="#result-event-(sem)">result event</a>. <em>Example</em>: in <em>Peter broke the window</em>, the event is described in terms of the result state that is reached (a broken window). (Section 7.3.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="resultative-complex-predicate-(cxn)">
@@ -15377,7 +13399,7 @@
 <strong>satellite-framing strategy (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> for expressing <a href="#event-(sem)">events</a> such that the manner of how the event comes about is expressed by a <a href="#manner-verb-(cxn)">manner verb</a>, and the <a href="#result-event-(sem)-verb-(cxn)">result</a> <span class="separation"/> <a href="#state-(sem)">state</a> (including also paths of motion) is expressed in a <a href="#satellite-(str)">satellite</a>. <em>Example</em>: <em>Sam strode into the room</em> uses the satellite-framing strategy – <em>stride</em> is a manner of motion verb, and the path of motion is expressed by the oblique phrase <em>into the room</em>. (Section 7.3.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#strategy-(def)">strategy</a> for expressing <a href="#event-(sem)">events</a> such that the manner of how the event comes about is expressed by a <a href="#manner-verb-(cxn)">manner verb</a>, and the <a href="#result-event-(sem)">result</a> <span class="separation"/> <a href="#state-(sem)">state</a> (including also paths of motion) is expressed in a <a href="#satellite-(str)">satellite</a>. <em>Example</em>: <em>Sam strode into the room</em> uses the satellite-framing strategy – <em>stride</em> is a manner of motion verb, and the path of motion is expressed by the oblique phrase <em>into the room</em>. (Section 7.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="scalar-concessive-conditional-strategy-(str)">
@@ -15640,12 +13662,6 @@
 <div class="cc" id="sensation-event-(sem)">
 <h2 class="name"><a href="#sensation-event-(sem)">sensation event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#sensation-event-(sem)-verb-(cxn)">sensation event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>sensation event (<i>sem</i>)</strong></span><span><a href="#sensation-verb-(cxn)">sensation verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">sensation event | bodily sensation event</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -15657,31 +13673,12 @@
 <strong>sensation event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="sensation-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#sensation-event-(sem)-verb-(cxn)">sensation event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>sensation event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#sensation-event-(sem)">sensation event (<i>sem</i>)</a></span><span><a href="#sensation-verb-(cxn)">sensation verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">sensation event/verb | sensation</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#experiential-event-(sem)">experiential event</a> involving an internal bodily or physiological sensation; and a <a href="#verb-(cxn)">verb</a> that expresses such an event. <em>Example</em>: <em>My head aches</em> is an example of a sensation event, and <em>ache</em> is the sensation verb. (Section 7.4)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#experiential-event-(sem)">experiential event</a> involving an internal bodily or physiological sensation. <em>Example</em>: <em>My head aches</em> is an example of a sensation event. (Section 7.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="sensation-verb-(cxn)">
 <h2 class="name"><a href="#sensation-verb-(cxn)">sensation verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#sensation-event-(sem)-verb-(cxn)">sensation event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#sensation-event-(sem)">sensation event (<i>sem</i>)</a></span><span><strong>sensation verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">sensation verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -15693,6 +13690,7 @@
 <strong>sensation verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#verb-(cxn)">verb</a> that expresses a <a href="#sensation-event-(sem)">sensation event</a>. <em>Example</em>: <em>My head aches</em> is an example of a sensation event, and <em>ache</em> is the sensation verb. (Section 7.4)</td></tr>
 </table>
 </div>
 <div class="cc" id="separative-comparative-(str)">
@@ -15900,7 +13898,7 @@
 <strong>single role strategy (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#strategy-(def)">strategy</a> of construing the <u>affected</u> <a href="#subject-phrase-(cxn)">subject</a> <span class="separation"/> <a href="#participant-(sem)">participant</a> as a single <a href="#role-(def)">role</a> in a <a href="#reflexive-event-(sem)-construction-(cxn)">reflexive</a> or <a href="#reciprocal-event-(sem)">reciprocal event</a>; hence, it is expressed by a single <a href="#argument-phrase-(cxn)">argument phrase</a> in a <a href="#reflexive-construction-(cxn)">reflexive construction</a> or a <a href="#reciprocal-construction-(cxn)">reciprocal construction</a>. <em>Examples</em>: English <em>Sam shaved</em> and <em>Mary and Sue met</em> construe the participants – Sam, and Mary and Sue, respectively – as playing a single role in the shaving and meeting events. The single role strategy may also be overtly coded: the Abkhaz Reflexive <em>l-c̜ə-l-k°abe-yt'</em> <q>She washed (herself)</q> is an Intransitive Verb form with the Reflexive prefix <em>c̜ə-</em>, and the Swahili Reciprocal <em>wa-na-pend-an-a</em> <q>they love each other</q> is an Intransitive Verb form with the Reciprocal suffix <em>-an</em>. (Section 7.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#strategy-(def)">strategy</a> of construing the <u>affected</u> <a href="#subject-phrase-(cxn)">subject</a> <span class="separation"/> <a href="#participant-(sem)">participant</a> as a single <a href="#role-(def)">role</a> in a <a href="#reflexive-event-(sem)">reflexive</a> or <a href="#reciprocal-event-(sem)">reciprocal event</a>; hence, it is expressed by a single <a href="#argument-phrase-(cxn)">argument phrase</a> in a <a href="#reflexive-construction-(cxn)">reflexive construction</a> or a <a href="#reciprocal-construction-(cxn)">reciprocal construction</a>. <em>Examples</em>: English <em>Sam shaved</em> and <em>Mary and Sue met</em> construe the participants – Sam, and Mary and Sue, respectively – as playing a single role in the shaving and meeting events. The single role strategy may also be overtly coded: the Abkhaz Reflexive <em>l-c̜ə-l-k°abe-yt'</em> <q>She washed (herself)</q> is an Intransitive Verb form with the Reflexive prefix <em>c̜ə-</em>, and the Swahili Reciprocal <em>wa-na-pend-an-a</em> <q>they love each other</q> is an Intransitive Verb form with the Reciprocal suffix <em>-an</em>. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="situating-(inf)">
@@ -16011,7 +14009,7 @@
 <strong>specialized dual role strategy (<i>str</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#strategy-(def)">strategy</a> of construing the <u>affected</u> <a href="#subject-phrase-(cxn)">subject</a> <span class="separation"/> <a href="#participant-(sem)">participant</a> as playing two distinct <a href="#role-(def)">roles</a> in a <a href="#reflexive-event-(sem)-construction-(cxn)">reflexive</a> or <a href="#reciprocal-event-(sem)">reciprocal event</a>; hence, it is expressed by two distinct <a href="#argument-phrase-(cxn)">argument phrases</a> in a <a href="#reflexive-construction-(cxn)">reflexive construction</a> or a <a href="#reciprocal-construction-(cxn)">reciprocal construction</a>, but with a special form functioning as the nonsubject argument phrase. <em>Examples</em>: English <em>I saw myself</em> and <em>Mary and Sue praised each other</em> construe the participants – I, and Mary and Sue, respectively – as playing two roles in the seeing and praising event, but with special object forms <em>myself</em> and <em>each other</em> to express that the events are a reflexive event and a reciprocal event, respectively. (Section 7.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#strategy-(def)">strategy</a> of construing the <u>affected</u> <a href="#subject-phrase-(cxn)">subject</a> <span class="separation"/> <a href="#participant-(sem)">participant</a> as playing two distinct <a href="#role-(def)">roles</a> in a <a href="#reflexive-event-(sem)">reflexive</a> or <a href="#reciprocal-event-(sem)">reciprocal event</a>; hence, it is expressed by two distinct <a href="#argument-phrase-(cxn)">argument phrases</a> in a <a href="#reflexive-construction-(cxn)">reflexive construction</a> or a <a href="#reciprocal-construction-(cxn)">reciprocal construction</a>, but with a special form functioning as the nonsubject argument phrase. <em>Examples</em>: English <em>I saw myself</em> and <em>Mary and Sue praised each other</em> construe the participants – I, and Mary and Sue, respectively – as playing two roles in the seeing and praising event, but with special object forms <em>myself</em> and <em>each other</em> to express that the events are a reflexive event and a reciprocal event, respectively. (Section 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="species-term-(cxn)">
@@ -16034,12 +14032,6 @@
 <div class="cc" id="specific-known-pronoun-(cxn)">
 <h2 class="name"><a href="#specific-known-pronoun-(cxn)">specific known pronoun (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#specific-known-referent-(inf)-pronoun-(cxn)">specific known referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>specific known pronoun (<i>cxn</i>)</strong></span><span><a href="#specific-known-referent-(inf)">specific known referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">specific known pronoun</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -16051,17 +14043,12 @@
 <strong>specific known pronoun (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#pronoun-(cxn)">pronoun</a> that expresses a <a href="#specific-known-referent-(inf)">specific known referent</a>. <em>Example</em>: if <em>Masha met with someone near the university</em> is used in a context where the speaker knows the identity of the person Masha met, then <em>someone</em> is a specific known pronoun expressing a specific known referent. (Section 3.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="specific-known-referent-(inf)">
 <h2 class="name"><a href="#specific-known-referent-(inf)">specific known referent (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#specific-known-referent-(inf)-pronoun-(cxn)">specific known referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#specific-known-pronoun-(cxn)">specific known pronoun (<i>cxn</i>)</a></span><span><strong>specific known referent (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">specific known referent</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -16073,31 +14060,12 @@
 <strong>specific known referent (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="specific-known-referent-(inf)-pronoun-(cxn)">
-<h2 class="name"><a href="#specific-known-referent-(inf)-pronoun-(cxn)">specific known referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>specific known referent (<i>inf</i>) / pronoun (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#specific-known-pronoun-(cxn)">specific known pronoun (<i>cxn</i>)</a></span><span><a href="#specific-known-referent-(inf)">specific known referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">specific known referent/pronoun | specific known</td></tr>
 <tr><th>Definition</th> <td class="ccinfo definition">a real-world <a href="#reference,-referent-(inf)">referent</a> whose identity is known to the speaker but not the hearer. <em>Example</em>: if <em>Masha met with someone near the university</em> is used in a context where the speaker knows the identity of the person Masha met, then <em>someone</em> is a specific known pronoun expressing a specific known referent. (Section 3.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="specific-unknown-pronoun-(cxn)">
 <h2 class="name"><a href="#specific-unknown-pronoun-(cxn)">specific unknown pronoun (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#specific-unknown-referent-(inf)-pronoun-(cxn)">specific unknown referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>specific unknown pronoun (<i>cxn</i>)</strong></span><span><a href="#specific-unknown-referent-(inf)">specific unknown referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">specific unknown pronoun</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -16109,17 +14077,12 @@
 <strong>specific unknown pronoun (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#pronoun-(cxn)">pronoun</a> that expresses a <a href="#specific-unknown-referent-(inf)">specific unknown referent</a>. <em>Example</em>: if <em>Masha met with somebody near the university</em> is used in a context where the speaker does not know the identity of the person Masha met, then <em>somebody</em> is a specific unknown pronoun expressing a specific unknown referent. (Section 3.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="specific-unknown-referent-(inf)">
 <h2 class="name"><a href="#specific-unknown-referent-(inf)">specific unknown referent (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#specific-unknown-referent-(inf)-pronoun-(cxn)">specific unknown referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#specific-unknown-pronoun-(cxn)">specific unknown pronoun (<i>cxn</i>)</a></span><span><strong>specific unknown referent (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">specific unknown referent</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -16131,31 +14094,12 @@
 <strong>specific unknown referent (<i>inf</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="specific-unknown-referent-(inf)-pronoun-(cxn)">
-<h2 class="name"><a href="#specific-unknown-referent-(inf)-pronoun-(cxn)">specific unknown referent (<i>inf</i>) / pronoun (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>specific unknown referent (<i>inf</i>) / pronoun (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#specific-unknown-pronoun-(cxn)">specific unknown pronoun (<i>cxn</i>)</a></span><span><a href="#specific-unknown-referent-(inf)">specific unknown referent (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">specific unknown referent/pronoun | specific unknown</td></tr>
 <tr><th>Definition</th> <td class="ccinfo definition">a real-world <a href="#reference,-referent-(inf)">referent</a> whose identity is known neither to the speaker nor to the hearer. <em>Example</em>: if <em>Masha met with somebody near the university</em> is used in a context where the speaker does not know the identity of the person Masha met, then <em>somebody</em> is a specific unknown pronoun expressing a specific unknown referent. (Section 3.5)</td></tr>
 </table>
 </div>
 <div class="cc" id="speech-act-causal-construction-(cxn)">
 <h2 class="name"><a href="#speech-act-causal-construction-(cxn)">speech act causal construction (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#speech-act-causal-relation-(sem)-construction-(cxn)">speech act causal relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>speech act causal construction (<i>cxn</i>)</strong></span><span><a href="#speech-act-causal-relation-(sem)">speech act causal relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">speech act causal construction</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -16170,17 +14114,12 @@
 <strong>speech act causal construction (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the construction expressing a <a href="#speech-act-causal-relation-(sem)">speech act causal relation</a>. <em>Example</em>: in <em>Since you asked, ten isn't a prime number</em>, there is a speech act causal relation between the request of the speaker whether ten is a prime number, and the performance of the speech act asserting that ten isn't a prime number. (Section 17.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="speech-act-causal-relation-(sem)">
 <h2 class="name"><a href="#speech-act-causal-relation-(sem)">speech act causal relation (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#speech-act-causal-relation-(sem)-construction-(cxn)">speech act causal relation (<i>sem</i>) / construction (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#speech-act-causal-construction-(cxn)">speech act causal construction (<i>cxn</i>)</a></span><span><strong>speech act causal relation (<i>sem</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">speech act causal relation</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -16192,20 +14131,7 @@
 <strong>speech act causal relation (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="speech-act-causal-relation-(sem)-construction-(cxn)">
-<h2 class="name"><a href="#speech-act-causal-relation-(sem)-construction-(cxn)">speech act causal relation (<i>sem</i>) / construction (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>speech act causal relation (<i>sem</i>) / construction (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#speech-act-causal-construction-(cxn)">speech act causal construction (<i>cxn</i>)</a></span><span><a href="#speech-act-causal-relation-(sem)">speech act causal relation (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">speech act causal relation/construction | speech act causal</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the semantic relation in a <a href="#conditional-relation-(sem)-construction-(cxn)">conditional</a>, <a href="#causal-(sem)">causal</a>, <a href="#concessive-relation-(sem)-construction-(cxn)">concessive</a>, or <a href="#concessive-conditional-construction-(cxn)">conditional concessive construction</a> that expresses a relation between a condition on performing a <a href="#speech-acts-(inf)">speech act</a> and the performance of that speech act; and the construction expressing that relation. <em>Example</em>: in <em>Since you asked, ten isn't a prime number</em>, there is a speech act causal relation between the request of the speaker whether ten is a prime number, and the performance of the speech act asserting that ten isn't a prime number. A speech act causal relation contrasts with a <a href="#content-causal-relation-(sem)">content causal relation</a> and an <a href="#epistemic-causal-relation-(sem)">epistemic causal relation</a>. (Section 17.3.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the semantic relation in a <a href="#conditional-relation-(sem)">conditional</a>, <a href="#causal-(sem)">causal</a>, <a href="#concessive-relation-(sem)">concessive</a>, or <a href="#concessive-conditional-construction-(cxn)">conditional concessive construction</a> that expresses a relation between a condition on performing a <a href="#speech-acts-(inf)">speech act</a> and the performance of that speech act; and the construction expressing that relation. <em>Example</em>: in <em>Since you asked, ten isn't a prime number</em>, there is a speech act causal relation between the request of the speaker whether ten is a prime number, and the performance of the speech act asserting that ten isn't a prime number. A speech act causal relation contrasts with a <a href="#content-causal-relation-(sem)">content causal relation</a> and an <a href="#epistemic-causal-relation-(sem)">epistemic causal relation</a>. (Section 17.3.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="speech-act-situation-(def)">
@@ -16219,12 +14145,6 @@
 <div class="cc" id="speech-acts-(cxn)">
 <h2 class="name"><a href="#speech-acts-(cxn)">speech acts (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#speech-acts-(inf-cxn)">speech acts (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>speech acts (<i>cxn</i>)</strong></span><span><a href="#speech-acts-(inf)">speech acts (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">speech acts</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -16243,31 +14163,12 @@
 <span><a href="#response-(cxn)">response (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="speech-acts-(inf-cxn)">
-<h2 class="name"><a href="#speech-acts-(inf-cxn)">speech acts (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>speech acts (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#speech-acts-(cxn)">speech acts (<i>cxn</i>)</a></span><span><a href="#speech-acts-(inf)">speech acts (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">speech acts</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">speech acts package the <a href="#propositional-content-(sem)">propositional content</a> of the utterance in such a way that the speaker wants or requires an explicit response from the addressee with respect to the propositional content; and the <a href="#construction-(def)">constructions</a> used to express this function. The speech acts that are most likely to be expressed as distinct constructions are the <a href="#declarative-(inf)">declarative</a>, the <a href="#interrogative-(inf)">interrogative</a>, the <a href="#imperative-hortative-(inf)">imperative–hortative</a> and its negative the <a href="#prohibitive-(inf)">prohibitive</a>, and the <a href="#exclamative-(inf)">exclamative</a>. (Section 12.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">constructions</a> used to express <a href="#speech-acts-(inf)">speech acts</a> functions. (Section 12.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="speech-acts-(inf)">
 <h2 class="name"><a href="#speech-acts-(inf)">speech acts (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#speech-acts-(inf-cxn)">speech acts (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#speech-acts-(cxn)">speech acts (<i>cxn</i>)</a></span><span><strong>speech acts (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">speech acts</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -16286,6 +14187,7 @@
 <span><a href="#response-(inf)">response (<i>inf</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">speech acts package the <a href="#propositional-content-(sem)">propositional content</a> of the utterance in such a way that the speaker wants or requires an explicit response from the addressee with respect to the propositional content. The speech acts that are most likely to be expressed as distinct constructions are the <a href="#declarative-(inf)">declarative</a>, the <a href="#interrogative-(inf)">interrogative</a>, the <a href="#imperative-hortative-(inf)">imperative–hortative</a> and its negative the <a href="#prohibitive-(inf)">prohibitive</a>, and the <a href="#exclamative-(inf)">exclamative</a>. (Section 12.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="split-argument-structure-strategy-(str)">
@@ -16327,12 +14229,6 @@
 <div class="cc" id="spontaneous-event-(sem)">
 <h2 class="name"><a href="#spontaneous-event-(sem)">spontaneous event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#spontaneous-event-(sem)-verb-(cxn)">spontaneous event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>spontaneous event (<i>sem</i>)</strong></span><span><a href="#spontaneous-verb-(cxn)">spontaneous verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">spontaneous event</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#middle-voice-(str)">middle voice (<i>str</i>)</a></td></tr>
@@ -16345,31 +14241,12 @@
 <strong>spontaneous event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="spontaneous-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#spontaneous-event-(sem)-verb-(cxn)">spontaneous event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>spontaneous event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#spontaneous-event-(sem)">spontaneous event (<i>sem</i>)</a></span><span><a href="#spontaneous-verb-(cxn)">spontaneous verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">spontaneous event/verb | spontaneous</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#monovalent-event-(sem)">monovalent event</a> involving a <a href="#participant-(sem)">participant</a> that undergoes a change without an external cause; and the <a href="#verb-(cxn)">verb</a> expressing that event. <em>Examples</em>: dying and melting are spontaneous events, and <em>die</em> and <em>melt</em> are spontaneous event verbs. (Sections 6.3.4, 7.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#monovalent-event-(sem)">monovalent event</a> involving a <a href="#participant-(sem)">participant</a> that undergoes a change without an external cause. <em>Examples</em>: dying and melting are spontaneous events. (Sections 6.3.4, 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="spontaneous-verb-(cxn)">
 <h2 class="name"><a href="#spontaneous-verb-(cxn)">spontaneous verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#spontaneous-event-(sem)-verb-(cxn)">spontaneous event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#spontaneous-event-(sem)">spontaneous event (<i>sem</i>)</a></span><span><strong>spontaneous verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">spontaneous verb</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -16381,6 +14258,7 @@
 <strong>spontaneous verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#verb-(cxn)">verb</a> expressing a <a href="#spontaneous-event-(sem)">spontaneous event</a>. <em>Examples</em>: dying and melting are spontaneous events, and <em>die</em> and <em>melt</em> are spontaneous event verbs. (Sections 6.3.4, 7.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="stable-(sem)">
@@ -17096,12 +14974,6 @@
 <div class="cc" id="temporary-predicate-(cxn)">
 <h2 class="name"><a href="#temporary-predicate-(cxn)">temporary predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#temporary-state-(sem)-predicate-(cxn)">temporary state (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>temporary predicate (<i>cxn</i>)</strong></span><span><a href="#temporary-state-(sem)">temporary state (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">temporary predicate</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -17113,17 +14985,12 @@
 <strong>temporary predicate (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#predicate-(cxn)">predicates</a> that express the class of <a href="#temporary-state-(sem)">temporary state</a> events. <em>Example</em>: being sick is a temporary state, and <em>(be) sick</em> is a temporary state predicate. (Section 6.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="temporary-state-(sem)">
 <h2 class="name"><a href="#temporary-state-(sem)">temporary state (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#temporary-state-(sem)-predicate-(cxn)">temporary state (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#temporary-predicate-(cxn)">temporary predicate (<i>cxn</i>)</a></span><span><strong>temporary state (<i>sem</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">temporary state</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -17135,20 +15002,7 @@
 <strong>temporary state (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="temporary-state-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#temporary-state-(sem)-predicate-(cxn)">temporary state (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>temporary state (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#temporary-predicate-(cxn)">temporary predicate (<i>cxn</i>)</a></span><span><a href="#temporary-state-(sem)">temporary state (<i>sem</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">temporary state/predicate | temporary</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#event-(sem)">event</a> class of <a href="#stative-(sem)">stative</a> properties that are temporary and thus have come about through some process; and the <a href="#predicate-(cxn)">predicates</a> that express events in this class. <em>Example</em>: being sick is a temporary state, and <em>(be) sick</em> is a temporary state predicate. (Section 6.3.3)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#event-(sem)">event</a> class of <a href="#stative-(sem)">stative</a> properties that are temporary and thus have come about through some process. <em>Example</em>: being sick is a temporary state. (Section 6.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="tense-(sem)">
@@ -17222,18 +15076,12 @@
 <strong>theme (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#semantic-role-(sem)">semantic role</a> including <a href="#participant-role-(sem)">participant roles</a> for a <a href="#participant-(sem)">participant</a> that is the transferred <a href="#entity-(sem)">entity</a> in a <a href="#transfer-event-(sem)">transfer event</a>. <em>Example</em>: in <em>I sent the forms to the accountant</em>, the entity transferred is the forms. The term <q>theme</q> is also used for the participant functioning as the <a href="#figure-(sem)">figure</a> in <a href="#motion-event-(sem)-verb-(cxn)">motion</a>, <a href="#application-event-(sem)-verb-(cxn)">application</a>, <a href="#removal-event-(sem)-verb-(cxn)">removal</a>, and other events involving the movement of the participant. (Section 6.1.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#semantic-role-(sem)">semantic role</a> including <a href="#participant-role-(sem)">participant roles</a> for a <a href="#participant-(sem)">participant</a> that is the transferred <a href="#entity-(sem)">entity</a> in a <a href="#transfer-event-(sem)">transfer event</a>. <em>Example</em>: in <em>I sent the forms to the accountant</em>, the entity transferred is the forms. The term <q>theme</q> is also used for the participant functioning as the <a href="#figure-(sem)">figure</a> in <a href="#motion-event-(sem)">motion</a>, <a href="#application-event-(sem)">application</a>, <a href="#removal-event-(sem)">removal</a>, and other events involving the movement of the participant. (Section 6.1.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="thetic-(cxn)">
 <h2 class="name"><a href="#thetic-(cxn)">thetic (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#thetic-(inf-cxn)">thetic (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>thetic (<i>cxn</i>)</strong></span><span><a href="#thetic-(inf)">thetic (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">thetic</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -17249,33 +15097,14 @@
 <span><a href="#event-central-(cxn)">event-central (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="thetic-(inf-cxn)">
-<h2 class="name"><a href="#thetic-(inf-cxn)">thetic (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>thetic (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#thetic-(cxn)">thetic (<i>cxn</i>)</a></span><span><a href="#thetic-(inf)">thetic (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">thetic | all new</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition"><a href="#information-packaging-(def)">information packaging</a> that does not split the information into a <a href="#topic-(inf)">topic</a> and a <a href="#comment-(inf)">comment</a>, as is done in the <a href="#topic-comment-(inf)">topic–comment</a> information packaging; and the <a href="#construction-(def)">construction</a> that expresses that information packaging. Instead, the information is presented as a single whole, hence the alternative name <q>all new</q>. <em>Example</em>: <em>TRUMP was elected!</em> (with accent on <em>Trump</em>), uttered on November 9, 2016, is thetic, in that this information is expressed as all new – in this case because it was unexpected at the time. (Sections 10.1.2, 11.1, <strong>11.3.1</strong>)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> that expresses a <a href="#thetic-(inf)">thetic</a> information packaging. <em>Example</em>: <em>TRUMP was elected!</em> (with accent on <em>Trump</em>), uttered on November 9, 2016, is thetic, in that this information is expressed as all new – in this case because it was unexpected at the time. (Sections 10.1.2, 11.1, <strong>11.3.1</strong>)</td></tr>
 </table>
 </div>
 <div class="cc" id="thetic-(inf)">
 <h2 class="name"><a href="#thetic-(inf)">thetic (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#thetic-(inf-cxn)">thetic (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#thetic-(cxn)">thetic (<i>cxn</i>)</a></span><span><strong>thetic (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">thetic</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">thetic | all new</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
 <tr><td class="flex">
@@ -17289,6 +15118,7 @@
 <span><a href="#event-central-(inf)">event-central (<i>inf</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition"><a href="#information-packaging-(def)">information packaging</a> that does not split the information into a <a href="#topic-(inf)">topic</a> and a <a href="#comment-(inf)">comment</a>, as is done in the <a href="#topic-comment-(inf)">topic–comment</a> information packaging. Instead, the information is presented as a single whole, hence the alternative name <q>all new</q>. <em>Example</em>: <em>TRUMP was elected!</em> (with accent on <em>Trump</em>), uttered on November 9, 2016, is thetic, in that this information is expressed as all new – in this case because it was unexpected at the time. (Sections 10.1.2, 11.1, <strong>11.3.1</strong>)</td></tr>
 </table>
 </div>
 <div class="cc" id="third-person-pronoun-(cxn)">
@@ -17411,12 +15241,6 @@
 <div class="cc" id="topic-comment-(cxn)">
 <h2 class="name"><a href="#topic-comment-(cxn)">topic–comment (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#topic-comment-(inf-cxn)">topic–comment (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>topic–comment (<i>cxn</i>)</strong></span><span><a href="#topic-comment-(inf)">topic–comment (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">topic–comment</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -17432,31 +15256,12 @@
 <span><a href="#verbal-clause-(cxn)">verbal clause (<i>cxn</i>)</a></span>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="topic-comment-(inf-cxn)">
-<h2 class="name"><a href="#topic-comment-(inf-cxn)">topic–comment (<i>inf/cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>topic–comment (<i>inf/cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#topic-comment-(cxn)">topic–comment (<i>cxn</i>)</a></span><span><a href="#topic-comment-(inf)">topic–comment (<i>inf</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">topic–comment | categorical</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#information-packaging-(def)">information packaging</a> in which one concept (the <a href="#comment-(inf)">comment</a>) is <a href="#predicate-(cxn)">predicated about</a> another concept which is <a href="#reference,-referent-(inf)">referred</a> to (the <a href="#topic-(inf)">topic</a>); and the <a href="#construction-(def)">construction</a> that expresses that information packaging. <em>Example</em>: <em>The bus stopped</em> is an instance of a topic–comment construction in which <em>stopped</em> is the comment and <em>The bus</em> is the topic. Topic–comment information packaging is basically synonymous with <a href="#predication-(inf)">predication</a>; the term <q>topic–comment</q> highlights the fact that a predication is a predication about a <a href="#reference,-referent-(inf)">referent</a>. (Sections 2.2.2, 10.1.2, 11.1, <strong>11.2.1</strong>)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#construction-(def)">construction</a> that expresses a <a href="#topic-comment-(inf)">topic–comment</a> information packaging. <em>Example</em>: <em>The bus stopped</em> is an instance of a topic–comment construction in which <em>stopped</em> is the comment and <em>The bus</em> is the topic. (Sections 2.2.2, 10.1.2, 11.1, <strong>11.2.1</strong>)</td></tr>
 </table>
 </div>
 <div class="cc" id="topic-comment-(inf)">
 <h2 class="name"><a href="#topic-comment-(inf)">topic–comment (<i>inf</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#topic-comment-(inf-cxn)">topic–comment (<i>inf/cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#topic-comment-(cxn)">topic–comment (<i>cxn</i>)</a></span><span><strong>topic–comment (<i>inf</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#information-packaging-(def)">information packaging</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">topic–comment</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -17471,6 +15276,7 @@
 <span><a href="#predicational-(inf)">predicational (<i>inf</i>)</a></span>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#information-packaging-(def)">information packaging</a> in which one concept (the <a href="#comment-(inf)">comment</a>) is <a href="#predicate-(cxn)">predicated about</a> another concept which is <a href="#reference,-referent-(inf)">referred</a> to (the <a href="#topic-(inf)">topic</a>). <em>Example</em>: <em>The bus stopped</em> is an instance of a topic–comment construction in which <em>stopped</em> is the comment and <em>The bus</em> is the topic. Topic–comment information packaging is basically synonymous with <a href="#predication-(inf)">predication</a>; the term <q>topic–comment</q> highlights the fact that a predication is a predication about a <a href="#reference,-referent-(inf)">referent</a>. (Sections 2.2.2, 10.1.2, 11.1, <strong>11.2.1</strong>)</td></tr>
 </table>
 </div>
 <div class="cc" id="topic-locational-hybrid-possessive-strategy-(str)">
@@ -17494,12 +15300,6 @@
 <div class="cc" id="transfer-event-(sem)">
 <h2 class="name"><a href="#transfer-event-(sem)">transfer event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#transfer-event-(sem)-verb-(cxn)">transfer event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>transfer event (<i>sem</i>)</strong></span><span><a href="#transfer-verb-(cxn)">transfer verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">transfer event</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -17511,31 +15311,12 @@
 <strong>transfer event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="transfer-event-(sem)-verb-(cxn)">
-<h2 class="name"><a href="#transfer-event-(sem)-verb-(cxn)">transfer event (<i>sem</i>) / verb (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>transfer event (<i>sem</i>) / verb (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#transfer-event-(sem)">transfer event (<i>sem</i>)</a></span><span><a href="#transfer-verb-(cxn)">transfer verb (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">transfer event/verb | transfer</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#trivalent-event-(sem)">trivalent event</a> involving physical transfer, usually also extended to <q class="dq">mental transfer</q>, that is used in defining the <a href="#ditransitive-construction-(cxn)">ditransitive construction</a>; and a <a href="#verb-(cxn)">verb</a> that expresses such an event. <em>Examples</em>: giving and sending are physical transfer events (and <em>give</em> and <em>send</em> are transfer verbs), and showing and telling are <q class="dq">mental transfer</q> events (and <em>show</em> and <em>tell</em> are <q class="dq">mental transfer</q> verbs). (Section 7.5.1)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#trivalent-event-(sem)">trivalent event</a> involving physical transfer, usually also extended to <q class="dq">mental transfer</q>, that is used in defining the <a href="#ditransitive-construction-(cxn)">ditransitive construction</a>. <em>Examples</em>: giving and sending are physical transfer events (and <em>give</em> and <em>send</em> are transfer verbs), and showing and telling are <q class="dq">mental transfer</q> events (and <em>show</em> and <em>tell</em> are <q class="dq">mental transfer</q> verbs). (Section 7.5.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="transfer-verb-(cxn)">
 <h2 class="name"><a href="#transfer-verb-(cxn)">transfer verb (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#transfer-event-(sem)-verb-(cxn)">transfer event (<i>sem</i>) / verb (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#transfer-event-(sem)">transfer event (<i>sem</i>)</a></span><span><strong>transfer verb (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">transfer verb</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#ditransitive-construction-(cxn)">ditransitive construction (<i>cxn</i>)</a></td></tr>
@@ -17548,6 +15329,7 @@
 <strong>transfer verb (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">a <a href="#verb-(cxn)">verb</a> that expresses a <a href="#transfer-event-(sem)">transfer event</a>. <em>Examples</em>: giving and sending are physical transfer events (and <em>give</em> and <em>send</em> are transfer verbs), and showing and telling are <q class="dq">mental transfer</q> events (and <em>show</em> and <em>tell</em> are <q class="dq">mental transfer</q> verbs). (Section 7.5.1)</td></tr>
 </table>
 </div>
 <div class="cc" id="transitive-construction-(cxn)">
@@ -17800,12 +15582,6 @@
 <div class="cc" id="uncontrolled-activity-(sem)">
 <h2 class="name"><a href="#uncontrolled-activity-(sem)">uncontrolled activity (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#uncontrolled-activity-(sem)-predicate-(cxn)">uncontrolled activity (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>uncontrolled activity (<i>sem</i>)</strong></span><span><a href="#uncontrolled-predicate-(cxn)">uncontrolled predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">uncontrolled activity</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -17817,31 +15593,12 @@
 <strong>uncontrolled activity (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="uncontrolled-activity-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#uncontrolled-activity-(sem)-predicate-(cxn)">uncontrolled activity (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>uncontrolled activity (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#uncontrolled-activity-(sem)">uncontrolled activity (<i>sem</i>)</a></span><span><a href="#uncontrolled-predicate-(cxn)">uncontrolled predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">uncontrolled activity/predicate | uncontrolled</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#event-(sem)">event</a> class of activities not under the control of an <a href="#agent-(sem)">agent</a> (apart from uncontrolled <a href="#bodily-action-(sem)">bodily actions</a> and <a href="#change-of-state-event-(sem)-verb-(cxn)">change of state</a>); and the <a href="#predicate-(cxn)">predicates</a> that express events in this class. <em>Example</em>: dying is an uncontrolled activity, and <em>die</em> is an uncontrolled activity predicate. (Section 6.3.3)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#event-(sem)">event</a> class of activities not under the control of an <a href="#agent-(sem)">agent</a> (apart from uncontrolled <a href="#bodily-action-(sem)">bodily actions</a> and <a href="#change-of-state-event-(sem)">change of state</a>). <em>Example</em>: dying is an uncontrolled activity. (Section 6.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="uncontrolled-predicate-(cxn)">
 <h2 class="name"><a href="#uncontrolled-predicate-(cxn)">uncontrolled predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#uncontrolled-activity-(sem)-predicate-(cxn)">uncontrolled activity (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#uncontrolled-activity-(sem)">uncontrolled activity (<i>sem</i>)</a></span><span><strong>uncontrolled predicate (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">uncontrolled predicate</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -17853,6 +15610,7 @@
 <strong>uncontrolled predicate (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#predicate-(cxn)">predicates</a> that express the class of <a href="#uncontrolled-activity-(sem)">uncontrolled activity</a> events. <em>Example</em>: dying is an uncontrolled activity, and <em>die</em> is an uncontrolled activity predicate. (Section 6.3.3)</td></tr>
 </table>
 </div>
 <div class="cc" id="undirected-change-(sem)">
@@ -17929,14 +15687,8 @@
 <div class="cc" id="utterance-event-(sem)">
 <h2 class="name"><a href="#utterance-event-(sem)">utterance event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#utterance-event-(sem)-predicate-(cxn)">utterance event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>utterance event (<i>sem</i>)</strong></span><span><a href="#utterance-predicate-(cxn)">utterance predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">utterance event</td></tr>
+<th>Alias(es)</th> <td class="ccinfo name">utterance event | utterance</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#independent-time-reference-(sem)">independent time reference (<i>sem</i>)</a></td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
 <table>
@@ -17947,31 +15699,12 @@
 <strong>utterance event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="utterance-event-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#utterance-event-(sem)-predicate-(cxn)">utterance event (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>utterance event (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#utterance-event-(sem)">utterance event (<i>sem</i>)</a></span><span><a href="#utterance-predicate-(cxn)">utterance predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">utterance event/predicate | utterance</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> of saying in which one <a href="#participant-(sem)">participant</a> is the <u>speaker</u> of the utterance and another participant is the utterance itself; and the <a href="#predicate-(cxn)">predicate</a> expressing such an event. <em>Example</em>: in <em>Sandy said, <q class="dq">I'm buying the house</q>, said</em> denotes the utterance event. Some predicates denoting utterance events include the <u>addressee</u> as an <a href="#argument-(inf)">argument</a>, as in <em>Sandy told me that she's buying the house</em>. (Section 18.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#event-(sem)">event</a> of saying in which one <a href="#participant-(sem)">participant</a> is the <u>speaker</u> of the utterance and another participant is the utterance itself. <em>Example</em>: in <em>Sandy said, <q class="dq">I'm buying the house</q>, said</em> denotes the utterance event. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="utterance-predicate-(cxn)">
 <h2 class="name"><a href="#utterance-predicate-(cxn)">utterance predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#utterance-event-(sem)-predicate-(cxn)">utterance event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#utterance-event-(sem)">utterance event (<i>sem</i>)</a></span><span><strong>utterance predicate (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">utterance predicate</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -17983,6 +15716,7 @@
 <strong>utterance predicate (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#predicate-(cxn)">predicate</a> expressing an <a href="#utterance-event-(sem)">utterance event</a>. <em>Example</em>: in <em>Sandy said, <q class="dq">I'm buying the house</q>, said</em> denotes the utterance event. Some predicates denoting utterance events include the <u>addressee</u> as an <a href="#argument-(inf)">argument</a>, as in <em>Sandy told me that she's buying the house</em>. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="vague-numeral-(cxn)">
@@ -18241,12 +15975,6 @@
 <div class="cc" id="wishing-event-(sem)">
 <h2 class="name"><a href="#wishing-event-(sem)">wishing event (<i>sem</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#wishing-event-(sem)-predicate-(cxn)">wishing event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<strong>wishing event (<i>sem</i>)</strong></span><span><a href="#wishing-predicate-(cxn)">wishing predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">wishing event</td></tr>
 <tr><th>Associated</th> <td class="ccinfo relation"><a href="#evaluative-predicate-(cxn)">evaluative predicate (<i>cxn</i>)</a> | <a href="#negative-epistemic-stance-(sem)">negative epistemic stance (<i>sem</i>)</a></td></tr>
@@ -18259,31 +15987,12 @@
 <strong>wishing event (<i>sem</i>)</strong>
 </td></tr>
 </table></td></tr>
-</table>
-</div>
-<div class="cc" id="wishing-event-(sem)-predicate-(cxn)">
-<h2 class="name"><a href="#wishing-event-(sem)-predicate-(cxn)">wishing event (<i>sem</i>) / predicate (<i>cxn</i>)</a></h2>
-<table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<strong>wishing event (<i>sem</i>) / predicate (<i>cxn</i>)</strong>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#wishing-event-(sem)">wishing event (<i>sem</i>)</a></span><span><a href="#wishing-predicate-(cxn)">wishing predicate (<i>cxn</i>)</a>
-</span></td></tr></table></td></tr>
-<tr><th>Type</th> <td class="ccinfo type"><a href="#meaning-(def)">meaning</a> / <a href="#construction-(def)">construction</a></td></tr>
-<th>Alias(es)</th> <td class="ccinfo name">wishing event/predicate | wishing</td></tr>
-<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#evaluative-event-(sem)">evaluative event</a> in which a positive evaluative judgment about a <a href="#proposition-(sem)">proposition</a> expressed by the <a href="#complement-dependent-clause-(cxn)">complement</a> of the wishing event is made, and there is a <a href="#negative-epistemic-stance-(sem)">negative epistemic stance</a> by the speaker toward the proposition; and the <a href="#predicate-(cxn)">predicate</a> expressing such an event. <em>Example</em>: in <em>Jill wishes that Joe had won the election</em>, the wishing predicate <em>wishes</em> expresses Jill's evaluation of Joe's winning the election, and also presupposes that the speaker believes that Joe didn't win the election. (Section 18.2.2)</td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">an <a href="#evaluative-event-(sem)">evaluative event</a> in which a positive evaluative judgment about a <a href="#proposition-(sem)">proposition</a> expressed by the <a href="#complement-dependent-clause-(cxn)">complement</a> of the wishing event is made, and there is a <a href="#negative-epistemic-stance-(sem)">negative epistemic stance</a> by the speaker toward the proposition. <em>Example</em>: in <em>Jill wishes that Joe had won the election</em>, the wishing predicate <em>wishes</em> expresses Jill's evaluation of Joe's winning the election, and also presupposes that the speaker believes that Joe didn't win the election. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="wishing-predicate-(cxn)">
 <h2 class="name"><a href="#wishing-predicate-(cxn)">wishing predicate (<i>cxn</i>)</a></h2>
 <table>
-<tr><th>Umbrella</th> <td class="ccinfo relation">
-<table><tr><td class="flex"><span>
-<a href="#wishing-event-(sem)-predicate-(cxn)">wishing event (<i>sem</i>) / predicate (<i>cxn</i>)</a>
-</span></td></tr><tr><td class="flex"><span>
-<a href="#wishing-event-(sem)">wishing event (<i>sem</i>)</a></span><span><strong>wishing predicate (<i>cxn</i>)</strong>
-</span></td></tr></table></td></tr>
 <tr><th>Type</th> <td class="ccinfo type"><a href="#construction-(def)">construction</a></td></tr>
 <th>Alias(es)</th> <td class="ccinfo name">wishing predicate</td></tr>
 <tr><th>Hierarchy</th> <td class="ccinfo relation"> <table>
@@ -18295,6 +16004,7 @@
 <strong>wishing predicate (<i>cxn</i>)</strong>
 </td></tr>
 </table></td></tr>
+<tr><th>Definition</th> <td class="ccinfo definition">the <a href="#predicate-(cxn)">predicate</a> expressing a <a href="#wishing-event-(sem)">wishing event</a>. <em>Example</em>: in <em>Jill wishes that Joe had won the election</em>, the wishing predicate <em>wishes</em> expresses Jill's evaluation of Joe's winning the election, and also presupposes that the speaker believes that Joe didn't win the election. (Section 18.2.2)</td></tr>
 </table>
 </div>
 <div class="cc" id="with-possessive-strategy-(str)">


### PR DESCRIPTION
Removed the 'umbrella' entries and fixed all associations between other concepts and those entries.

I made sure to always reference (in the definition) the other pair that formed the umbrella entry. For example, the new definition for utterance predicate reads as "the <a>predicate</a> expressing an <a>utterance event</a>", making sure that the event is being referenced. 

Only in two cases the definitions were duplicated:

- definite pronoun/article (cxn)
- indefinite pronoun/article (cxn)

I will check with Croft to see what's the best way to define these.
